### PR TITLE
Fix/database fields and hana database

### DIFF
--- a/config/examples/postgres.example.yml
+++ b/config/examples/postgres.example.yml
@@ -18,6 +18,13 @@ database: ${PG_DATABASE}
 connection_params: {}
 
 resources:
+  # Full-table style: omit `fields` to include every column returned by the extract (all cast to string),
+  # same idea as REST resources without a field list. Prefer an explicit `fields` block when you need
+  # a subset of columns, stable renames (`name` vs `source`), or a documented output contract.
+  users_full:
+    method: GET
+    database_schema: public
+    database_table: users
   users:
     method: GET
     database_schema: public

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -70,3 +70,4 @@ sources:
 | [Loading](loading.md) | Delta save modes (overwrite, append, merge), S3 |
 | [Auth](auth.md) | OAuth JWT, bearer token, API key |
 | [Transformations](transformations.md) | add_column, add_column_from_request, ensure_param_values_in_output |
+| **PostgreSQL / HANA** | `type: postgresql` or `type: hana` with JDBC-style connection fields. PostgreSQL requires `database`. For HANA, `database` is the **tenant database name** passed to hdbcli as `databaseName` (must match a real tenant; errors such as `database '…' not connected` usually mean the wrong name). It can be omitted when your `host:port` already targets a single tenant. See [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml). |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,23 @@
 # Core dependencies
-python-dotenv==1.0.1
-requests==2.31.0
-PyJWT==2.8.0
-cryptography==42.0.5
-python-dateutil==2.8.2
 boto3==1.34.69
 click==8.1.7
+cryptography==42.0.5
+psutil==7.1.3
+python-dotenv==1.0.1
+python-dateutil==2.8.2
+PyJWT==2.8.0
+requests==2.31.0
 redis==5.0.1
 databricks-sdk==0.68.0
-psutil==7.1.3
 
 # Data processing
-sqlalchemy==2.0.36
-pyspark==3.5.0
-delta-spark==3.1.0
 pandas==2.2.3
+pyspark==3.5.0
 pyarrow>=15.0.1
+delta-spark==3.1.0
+hdbcli==2.23.27
+sqlalchemy==1.4.54
+sqlalchemy-hana==0.5.0
 
 # Configuration management
 pydantic-settings==2.2.1

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -704,10 +704,13 @@ class ResourceConfig(BaseModel):
         description="Request body keys to strip before sending (used for backfill-only fields that drive date generation but shouldn't be sent to the API)",
     )
 
-    # Fields to extract from response. If not specified, all fields will be extracted.
+    # Fields to extract from response or database extract. If not specified, all fields are used.
     fields: Optional[List[SchemaField]] = Field(
         default=None,
-        description="Fields to extract from response. If not specified, all fields will be extracted.",
+        description=(
+            "Fields to extract from REST responses or JDBC/HANA extracts. "
+            "If not specified, all fields from the response or extract are used (string-typed for databases)."
+        ),
     )
     transformations: List[Transformation] = Field(default_factory=list)
     loading: Optional[LoadingConfig] = Field(
@@ -942,7 +945,14 @@ class SourceConfig(BaseModel):
     port: Optional[Union[int, str]] = Field(default=None, description="Database port")
     username: Optional[str] = Field(default=None, description="Database user")
     password: Optional[str] = Field(default=None, description="Database password")
-    database: Optional[str] = Field(default=None, description="Database/catalog name")
+    database: Optional[str] = Field(
+        default=None,
+        description=(
+            "Database/catalog name. Required for postgresql. "
+            "Optional for hana: set to the HANA tenant database name when using a shared SQL port; "
+            "omit when the host:port already targets a single tenant."
+        ),
+    )
     connection_params: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Extra JDBC properties or URL query parameters (driver-specific).",
@@ -968,7 +978,7 @@ class SourceConfig(BaseModel):
                 raise ValueError(f"{self.type.value} source requires port")
             if not self.username or self.password is None:
                 raise ValueError(f"{self.type.value} source requires username and password")
-            if not self.database:
+            if self.type == SourceType.POSTGRESQL and not (self.database or "").strip():
                 raise ValueError(f"{self.type.value} source requires database")
             for resource_name, resource in self.resources.items():
                 if not resource.enabled:

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -23,6 +23,7 @@ from src.config.config_models import (
     PaginationConfig,
     PaginationType,
     ResourceConfig,
+    SchemaField,
     SourceConfig,
     SourceType,
 )
@@ -1788,19 +1789,17 @@ class DynamicHandler(BaseHandler):
     ) -> Optional[DataFrame]:
         """
         Connect, extract via Spark JDBC / HANA driver, project to configured fields (string typed).
+
+        When ``fields`` is omitted or empty, output columns match the extract (name and source
+        equal each result column), same idea as REST resources without an explicit field list.
         """
         resource_config = resource_meta.config
-        fields = resource_config.fields
-        if not fields:
-            raise HandlerError(
-                "Database resources require fields (output schema) in configuration",
-                operation="process_resource",
-                details={"resource_name": resource_meta.resource_name},
-            )
+        configured_fields = resource_config.fields
         schema = str(resource_config.database_schema).strip()
         table = str(resource_config.database_table).strip()
         all_df: Optional[DataFrame] = None
         service.connect()
+        inferred_schema_logged = False
         try:
             for _ctx in request_contexts:
                 df = service.extract_table(
@@ -1809,6 +1808,20 @@ class DynamicHandler(BaseHandler):
                     select_query=resource_config.database_select_query,
                     spark_session=self.spark,
                 )
+                if configured_fields:
+                    fields = configured_fields
+                else:
+                    fields = [SchemaField(name=c, source=c) for c in df.columns]
+                    if not inferred_schema_logged:
+                        self.logger.info(
+                            "Database extract has no configured fields; inferring output columns from extract",
+                            extra_fields={
+                                "resource_name": resource_meta.resource_name,
+                                "source": resource_meta.source_name,
+                                "inferred_columns": list(df.columns),
+                            },
+                        )
+                        inferred_schema_logged = True
                 select_cols = []
                 for f in fields:
                     if f.source not in df.columns:
@@ -2509,15 +2522,13 @@ class DynamicHandler(BaseHandler):
                 for resource_name, resource_config in source_config.resources.items():
                     self.logger.debug(f"Validating resource: {resource_name}")
 
-                    # Validate schema fields
-                    if not resource_config.fields:
-                        raise HandlerError(f"No schema defined for resource: {resource_name}")
-
-                    for field in resource_config.fields:
-                        if not field.name:
-                            raise HandlerError(
-                                f"Invalid schema field in {resource_name}: name is required"
-                            )
+                    # Validate schema fields when explicitly configured (optional for REST and DB)
+                    if resource_config.fields:
+                        for field in resource_config.fields:
+                            if not field.name:
+                                raise HandlerError(
+                                    f"Invalid schema field in {resource_name}: name is required"
+                                )
 
                     # Validate loading configuration (if provided)
                     if resource_config.loading:

--- a/src/service/hana_service.py
+++ b/src/service/hana_service.py
@@ -120,8 +120,11 @@ class HanaService(SqlDatabaseService):
             f"hana://{self.config.username}:{password}@"
             f"{self.config.host}:{int(self.config.port)}"
         )
-        if self.config.database:
-            connection_string = f"{connection_string}/{self.config.database}"
+        # hdbcli `databaseName` must match a real HANA tenant; omit URL path when unset so
+        # tenant-scoped SQL ports (common on BW) can connect without a bogus placeholder.
+        db = (self.config.database or "").strip()
+        if db:
+            connection_string = f"{connection_string}/{db}"
         if self.config.connection_params:
             param_parts = [f"{key}={value}" for key, value in self.config.connection_params.items()]
             if param_parts:

--- a/tests/test_database_sources.py
+++ b/tests/test_database_sources.py
@@ -70,3 +70,30 @@ def test_hana_source_valid():
         resources={"dim": _db_resource()},
     )
     assert cfg.type == SourceType.HANA
+
+
+def test_hana_source_valid_without_database():
+    cfg = SourceConfig(
+        type=SourceType.HANA,
+        host="hana.example",
+        port="30244",
+        username="u",
+        password="p",
+        database=None,
+        resources={"dim": _db_resource()},
+    )
+    assert cfg.type == SourceType.HANA
+    assert cfg.database is None
+
+
+def test_postgresql_source_rejects_empty_database():
+    with pytest.raises(ValidationError, match="requires database"):
+        SourceConfig(
+            type=SourceType.POSTGRESQL,
+            host="localhost",
+            port=5432,
+            username="u",
+            password="p",
+            database="",
+            resources={"r": _db_resource()},
+        )

--- a/tests/test_handler/test_dynamic_handler_database_fields.py
+++ b/tests/test_handler/test_dynamic_handler_database_fields.py
@@ -1,0 +1,87 @@
+"""Tests for optional database ``fields`` in ``DynamicHandler._build_database_dataframe``."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from src.config.config_models import ResourceConfig, SchemaField
+from src.handler.dynamic_handler import DynamicHandler
+from src.planner.execution_plan import ResourceMetadata
+from src.utils.logger import get_logger
+
+
+@pytest.fixture(scope="module")
+def spark_session() -> SparkSession:
+    spark = (
+        SparkSession.builder.master("local[1]")
+        .appName("test_db_fields")
+        .config("spark.driver.host", "127.0.0.1")
+        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.ui.enabled", "false")
+        .config("spark.ui.showConsoleProgress", "false")
+        .getOrCreate()
+    )
+    yield spark
+    spark.stop()
+
+
+class _FakeDbService:
+    def __init__(self, spark: SparkSession) -> None:
+        self._spark = spark
+
+    def connect(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    def extract_table(self, schema, table, select_query=None, spark_session=None):
+        return self._spark.createDataFrame([(1, "x")], schema=["id", "label"])
+
+
+def test_build_database_dataframe_infers_fields_when_omitted(spark_session: SparkSession) -> None:
+    handler = object.__new__(DynamicHandler)
+    handler.spark = spark_session
+    handler.logger = get_logger("test_dynamic_handler_db")
+
+    rc = ResourceConfig(method="GET", database_schema="public", database_table="users")
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies=set(),
+        batch_inputs={},
+        config=rc,
+    )
+
+    out = DynamicHandler._build_database_dataframe(
+        handler, _FakeDbService(spark_session), meta, request_contexts=[{}]
+    )
+    assert out is not None
+    assert set(out.columns) == {"id", "label"}
+    for field in out.schema.fields:
+        assert str(field.dataType).startswith("StringType")
+
+
+def test_build_database_dataframe_respects_configured_fields(spark_session: SparkSession) -> None:
+    handler = object.__new__(DynamicHandler)
+    handler.spark = spark_session
+    handler.logger = get_logger("test_dynamic_handler_db")
+
+    rc = ResourceConfig(
+        method="GET",
+        database_schema="public",
+        database_table="users",
+        fields=[SchemaField(name="user_id", source="id")],
+    )
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies=set(),
+        batch_inputs={},
+        config=rc,
+    )
+
+    out = DynamicHandler._build_database_dataframe(
+        handler, _FakeDbService(spark_session), meta, request_contexts=[{}]
+    )
+    assert out is not None
+    assert out.columns == ["user_id"]


### PR DESCRIPTION
## Summary

This PR aligns database ingestion with REST-style configuration and fixes misleading HANA `databaseName` defaults.

### Optional `fields` for PostgreSQL / HANA

- When `fields` is omitted (or empty), the handler infers output columns from the JDBC/HANA extract (`name` and `source` equal each result column) and keeps the existing string cast behavior.
- **`DynamicHandler.validate()`** no longer requires every resource under a source to define `fields`; entries are validated only when `fields` is present (consistent with REST).

### HANA tenant / `database` parameter

- **`database` is required for PostgreSQL only**; for **HANA** it is optional so the SQLAlchemy URL can omit the `/database` segment when the SQL port already targets a tenant.
- **`HanaService`** only appends `/{database}` when the value is non-empty after trimming.
- **Local SAP example**: removed the `:-HDB` default (placeholder was often wrong and caused hdbcli errors like `database 'HDB' not connected`). Ingestion working for SAP BW.

### Docs and tests

- **`config/examples/postgres.example.yml`**: example without `fields` plus comments on when to declare `fields`.
- **`ResourceConfig.fields`**: description updated for REST and DB extracts.
- **Tests**: handler tests for inferred vs explicit DB fields; config tests for HANA without `database` and PostgreSQL with empty `database`.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
