### PR TITLE
Feature/deployment aid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ AWS_PROFILE=your-aws-profile
 # Bucket for pipeline writes (must match loading defaults in `config/defaults.yml`)
 S3_INGESTION_BUCKET=your-ingestion-bucket-name
 
+# Promote local operator config to S3 (one-off / CI):
+#   python -m src.utils.s3_config_push s3://your-bucket/your-prefix/
+# [OPTIONAL] ECS/Fargate: pull operator config from S3 before the app starts (boto3 in
+# docker/startup.sh; no AWS CLI). Target is CONFIG_PATH if set, else /app/config.
+# SPINE_CONFIG_S3_URI=s3://your-bucket/your-prefix/config/
+# See docs/deployment/ecs-s3-reference.md
+
 # [OPTIONAL] Separate bucket for audit / control-plane tables if you use that layout
 # S3_CONTROL_BUCKET=your-control-bucket-name
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ src/
 | **Auth** | [OAuth JWT, bearer token, API key](docs/configuration/auth.md) |
 | **Transformations** | [add_column, add_column_from_request, ensure_param_values](docs/configuration/transformations.md) |
 | **Deployment** | [Docker, GitHub Actions, GHCR](docs/deployment.md) |
+| **ECS / Fargate + S3 (reference)** | [S3 push/pull boto3, IAM, ECS task def](docs/deployment/ecs-s3-reference.md) |
 | **Development** | [Linting, testing, debugging, extending](docs/development.md) |
 
 ---

--- a/docker/README.md
+++ b/docker/README.md
@@ -84,7 +84,7 @@ If you add private wheels later, you can use a BuildKit secret and `pip.conf` du
 
 - `Dockerfile` — Python 3.12, Java 21, Redis, application
 - `docker-compose.yml` — Local development with volume mounts
-- `startup.sh` — Starts Redis, then runs the pipeline
+- `startup.sh` — Starts Redis, optional S3 config pull, then runs the pipeline
 
 ## Apple Silicon (M1/M2)
 

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
+set -euo pipefail
+
+# Log to stderr so messages stay ordered with Python logging on the same stream
+# in Docker/ECS (awslogs captures container stdout+stderr).
 
 # Start Redis server in the background
 redis-server /etc/redis/redis.conf --daemonize yes
 
 # Wait for Redis to be ready
 until redis-cli ping > /dev/null 2>&1; do
-  echo "Waiting for Redis to be ready..."
+  echo "[spine-startup] Waiting for Redis..." >&2
   sleep 1
 done
+echo "[spine-startup] Redis is ready." >&2
 
-# Run the Python application
+# Optional: pull operator config from S3 (boto3; no AWS CLI). Off when unset.
+if [ -n "${SPINE_CONFIG_S3_URI:-}" ]; then
+  SYNC_TARGET="${CONFIG_PATH:-/app/config}"
+  mkdir -p "${SYNC_TARGET}"
+  echo "[spine-startup] Pulling config from ${SPINE_CONFIG_S3_URI} -> ${SYNC_TARGET}" >&2
+  python -m src.utils.s3_config_pull "${SPINE_CONFIG_S3_URI}" "${SYNC_TARGET}"
+  export CONFIG_PATH="${SYNC_TARGET}"
+  echo "[spine-startup] S3 config pull finished." >&2
+else
+  echo "[spine-startup] SPINE_CONFIG_S3_URI unset; skipping S3 pull." >&2
+fi
+
+echo "[spine-startup] Starting python -m src.main ..." >&2
 exec python -m src.main "$@" 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,6 +5,7 @@
 - [Docker Local Development](#docker-local-development)
 - [CI and container images (GitHub Actions)](#ci-and-container-images-github-actions)
 - [Runtime configuration](#runtime-configuration)
+- [ECS Fargate and external config (reference)](deployment/ecs-s3-reference.md)
 - [Error Handling and Monitoring](#error-handling-and-monitoring)
 
 ## Docker Local Development
@@ -34,6 +35,7 @@ Images are public or private according to your GitHub package visibility setting
 - Set environment variables via your orchestrator (for example Kubernetes secrets, AWS Secrets Manager/SSM, or plain `.env` in development).
 - If you run without the default repo layout (for example a minimal image without operator config baked in), set `CONFIG_PATH` to an **absolute** path to a directory that contains `defaults.yml`, `sources/`, and optionally `queries/` (see [Configuration overview](configuration/overview.md)).
 - For AWS destinations, configure IAM for S3 and related services as needed.
+- For **ECS Fargate**, promoting config to **S3**, optional **`SPINE_CONFIG_S3_URI`** pull at container start (boto3), GHCR image pinning, and task-definition patterns (all placeholders), see the [ECS + S3 reference](deployment/ecs-s3-reference.md), including `python -m src.utils.s3_config_push` for one-off or CI uploads.
 
 ## Error Handling and Monitoring
 

--- a/docs/deployment/ecs-s3-reference.md
+++ b/docs/deployment/ecs-s3-reference.md
@@ -111,7 +111,7 @@ Example URI (neutral): `s3://example-org-spine-config/prod/`
 |----------|----------|---------|
 | `SPINE_CONFIG_S3_URI` | Optional | When set, `docker/startup.sh` pulls this prefix into the sync target **before** `python -m src.main` (boto3). When unset, no S3 read for config at start. |
 | `CONFIG_PATH` | Optional | **Absolute** path for config after pull. If unset while `SPINE_CONFIG_S3_URI` is set, pull uses **`/app/config`**. If both unset, Spine uses its normal default (`/app/config` via `CONFIG_PATH=.`). |
-| `LOG_LEVEL` | Optional | Set to **`DEBUG`** temporarily to log `valid_source_config_count` and `source_names` after config load; startup lines use the **`[spine-startup]`** prefix on stderr (same CloudWatch log stream as the app). |
+| `LOG_LEVEL` | Optional | Set to **`DEBUG`**, can be adjusted as defined in `src/utils/logger.py`.|
 | Other app secrets | As needed | Use `secrets` from AWS Secrets Manager or SSM Parameter Store as supported by ECS. |
 
 ---

--- a/docs/deployment/ecs-s3-reference.md
+++ b/docs/deployment/ecs-s3-reference.md
@@ -1,0 +1,136 @@
+# Reference: ECS Fargate, GHCR, and external operator config (S3)
+
+This page is **one** documented way to run Spine on AWS. It uses **placeholders only** (`s3://your-bucket/your-prefix/`, generic IAM actions). It is not the only supported deployment: operators may use bind mounts, EFS, init containers, or a **child** wrapper image.
+
+---
+
+## Who does what
+
+| Layer | What it is | Where it lives |
+|-------|------------|----------------|
+| **Spine (OSS)** | Generic image, `CONFIG_PATH` contract, **boto3** pull at start when `SPINE_CONFIG_S3_URI` is set, optional **CLI** `s3_config_push` for promotion | This repository and `ghcr.io` (or your fork’s registry) |
+| **Operator** | `defaults.yml`, `sources/*.yml`, `queries/*.sql`, secrets, how you promote config | Your machine, CI, and AWS resources in **your** account |
+| **Orchestration** | VPC, IAM, ECS task definitions, scheduling, observability | Your AWS account and tooling of your choice |
+
+Spine stays generic: the public image does not bake in account-specific ARNs or bucket names.
+
+### Config flow
+
+S3 is not a filesystem mount. **Promotion** (upload) and **runtime** (files on disk inside the task) are separate unless you connect them.
+
+```mermaid
+flowchart LR
+  devCI[Operator_or_CI]
+  s3put["s3:PutObject"]
+  s3prefix[S3_prefix]
+  ecsPull["Pull_at_start_or_other"]
+  cfgPath[CONFIG_PATH]
+  spine[Spine_process]
+
+  devCI --> s3put --> s3prefix
+  s3prefix --> ecsPull --> cfgPath --> spine
+```
+
+1. **Promotion:** upload a `CONFIG_PATH`-shaped tree to `s3://your-bucket/your-prefix/` (for example with `python -m src.utils.s3_config_push`, `aws s3 sync`, or CI). Requires `s3:PutObject` (and listing as your tooling needs).
+2. **Runtime:** files must exist on disk at `CONFIG_PATH` before `python -m src.main`. The stock image can **pull from S3 using boto3** when `SPINE_CONFIG_S3_URI` is set (see below)—**no AWS CLI, no sidecar, no child image** for that path. Alternatives remain: `aws s3 sync` in `command`, EFS, init containers, etc.
+
+---
+
+## ECS: simplest path (env only, default entrypoint)
+
+The public image **`ENTRYPOINT`** is `/startup.sh` (Redis, then `python -m src.main`). You do **not** need to override `command` or `entryPoint` if you use the built-in pull:
+
+1. Set **`SPINE_CONFIG_S3_URI`** to your operator prefix, for example `s3://<bucket-from-your-infra>/config/` (objects under that prefix should mirror `defaults.yml`, `sources/…`, `queries/…`).
+2. Optionally set **`CONFIG_PATH`** to an **absolute** directory inside the container (recommended for clarity). If unset, pull targets **`/app/config`**, which matches Spine’s default resolution for `CONFIG_PATH=.`.
+
+`startup.sh` runs `python -m src.utils.s3_config_pull` (boto3) before the app. The task **IAM role** must allow **`s3:GetObject`** on `prefix/*` and **`s3:ListBucket`** on the bucket (often prefix-scoped in the bucket policy).
+
+**Merge vs delete:** pull **downloads and overwrites** keys that exist in S3; it does **not** delete extra files already on disk under the target path (unlike `aws s3 sync --delete`). The image may ship template files under `/app/config`; if that is a problem, set `CONFIG_PATH` to a dedicated empty path (for example `/app/config-runtime`) and pull there instead.
+
+---
+
+## ECS: how S3 config reaches the container (all options)
+
+**Important:** a task definition does **not** mount S3. The process only reads **local files**.
+
+| Approach | What you set | Notes |
+|----------|----------------|------|
+| **Built-in boto3 pull** | `SPINE_CONFIG_S3_URI` (+ optional `CONFIG_PATH`) | No AWS CLI; keep default `ENTRYPOINT`. |
+| **`aws s3 sync` in `command`** | Override `command` / `entryPoint` | Requires AWS CLI in the image or a wrapper image. |
+| **EFS** | Volume mount + `CONFIG_PATH` on the mount | Different operational model. |
+
+---
+
+## Do I need to update the task definition when I change config on S3?
+
+**Usually no** for the **built-in pull** or `sync` on every start: each new task run downloads the **current** objects for that prefix (into ephemeral disk or over the previous layer). Changing objects in S3 is enough for the **next** run.
+
+**You register a new revision** when you change **how** the task runs (image, CPU/memory, **environment variable keys/values that encode infra** such as a different bucket URI if you store it in the task def, secrets ARNs, `command`/`entryPoint`, IAM, etc.).
+
+---
+
+## Promote local `config/` to S3 (Spine CLI)
+
+One-off or CI step from a checkout that has your real operator files under `config/`:
+
+```bash
+python -m src.utils.s3_config_push s3://your-bucket/your-prefix/
+```
+
+- Resolves the local tree like runtime `CONFIG_PATH`: uses the `CONFIG_PATH` environment variable if set (absolute path, or relative segment under `config/`), otherwise `config/` at the repo root.
+- Uploads only **operator** paths: `defaults.yml`, `sources/**/*.yml`, `queries/**/*.sql`.
+- Skips templates and noise: `config/examples/`, `*.example.yml`, `README.md`, `.gitkeep`.
+
+Requires AWS credentials (profile or env) with **`s3:PutObject`** on `your-prefix/*` and **`s3:ListBucket`** on the bucket if your tooling needs it.
+
+---
+
+## Container image: GitHub Container Registry (GHCR)
+
+- **Public package:** ECS task definitions usually omit `repositoryCredentials`; any principal that can pull from `ghcr.io` can use the image reference.
+- **Private package:** Configure `repositoryCredentials` (for example a Secrets Manager ARN for a GitHub PAT or deploy key) on the container definition, and grant the **task execution role** permission to read that secret.
+- **Production pinning:** Prefer an **immutable digest** or a **semver tag** (`v1.2.3`), not a floating `latest`, so every revision is reproducible. The project’s CI publishes tags on `main` and on `v*` tags; pick the tag or digest your change control approves.
+
+---
+
+## S3 layout (contract)
+
+Under a single S3 **prefix**, mirror the directory Spine expects at `CONFIG_PATH`:
+
+- `defaults.yml`
+- `sources/*.yml` (nested paths under `sources/` are fine)
+- `queries/*.sql` (if used)
+
+Example URI (neutral): `s3://example-org-spine-config/prod/`
+
+---
+
+## Environment variables (ECS task definition)
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `SPINE_CONFIG_S3_URI` | Optional | When set, `docker/startup.sh` pulls this prefix into the sync target **before** `python -m src.main` (boto3). When unset, no S3 read for config at start. |
+| `CONFIG_PATH` | Optional | **Absolute** path for config after pull. If unset while `SPINE_CONFIG_S3_URI` is set, pull uses **`/app/config`**. If both unset, Spine uses its normal default (`/app/config` via `CONFIG_PATH=.`). |
+| `LOG_LEVEL` | Optional | Set to **`DEBUG`** temporarily to log `valid_source_config_count` and `source_names` after config load; startup lines use the **`[spine-startup]`** prefix on stderr (same CloudWatch log stream as the app). |
+| Other app secrets | As needed | Use `secrets` from AWS Secrets Manager or SSM Parameter Store as supported by ECS. |
+
+---
+
+## AWS checklist
+
+Use the AWS console, CloudFormation, CDK, Terraform, or any other approach—the items are the same:
+
+1. **S3 bucket and prefix** for operator config (content may be uploaded by CI or `s3_config_push`).
+2. **Task role** (runtime): `s3:GetObject` and `s3:ListBucket` (with `prefix` condition) on that prefix when using `SPINE_CONFIG_S3_URI`; plus any permissions your loaders and sources need (for example S3 writes, Databricks, etc.).
+3. **Task execution role**: pull from GHCR; if the GHCR package is private, read the secret used in `repositoryCredentials`.
+4. **Task definition**: image **digest or version tag**; environment `SPINE_CONFIG_S3_URI` (and optionally explicit `CONFIG_PATH`); keep default **`ENTRYPOINT`** `/startup.sh` unless you choose the AWS CLI `command` path; `secrets` for `.env`-style values; logging configuration.
+5. **Networking**: outbound path to `ghcr.io` (often NAT); access to S3 via **VPC gateway endpoint** or NAT.
+6. **Start order:** handled by `/startup.sh` when using `SPINE_CONFIG_S3_URI` (pull, then app). For other patterns, ensure files exist on disk before `python -m src.main`.
+
+---
+
+
+## Related documentation
+
+- [Deployment overview](deployment.md) — Docker, CI, GHCR, runtime env vars.
+- [Configuration overview](../configuration/overview.md) — `CONFIG_PATH` and directory layout.

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -160,6 +160,14 @@ class ConfigLoader:
                 details={"path": str(defaults_path)},
             )
 
+        self.logger.debug(
+            "Loaded defaults.yml",
+            extra_fields={
+                "path": str(defaults_path.resolve()),
+                "config_dir": str(config_dir.resolve()),
+            },
+        )
+
         sources_dir = config_dir / "sources"
         sources: Dict[str, Any] = {}
         if sources_dir.exists() and sources_dir.is_dir():
@@ -177,6 +185,23 @@ class ConfigLoader:
                     ) from e
                 self._validate_source_file(source_content, source_file, source_name)
                 sources[source_name] = source_content
+
+        self.logger.debug(
+            "Scanned sources/*.yml for pipeline source configs",
+            extra_fields={
+                "config_dir": str(config_dir.resolve()),
+                "valid_source_config_count": len(sources),
+                "source_names": sorted(sources.keys()),
+            },
+        )
+        if not sources:
+            self.logger.warning(
+                "No valid source YAML files under sources/*.yml (defaults.yml is present but no loadable sources)",
+                extra_fields={
+                    "config_dir": str(config_dir.resolve()),
+                    "sources_dir": str(sources_dir),
+                },
+            )
 
         raw_config = {
             "version": defaults_config.get("version", "1.0"),

--- a/src/utils/s3_config_pull.py
+++ b/src/utils/s3_config_pull.py
@@ -39,7 +39,7 @@ def pull_s3_prefix_to_directory(uri: str, target: Path) -> None:
     target = target.resolve()
     target.mkdir(parents=True, exist_ok=True)
 
-    count = 0
+    downloaded_any = False
     try:
         for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
             for obj in page.get("Contents", []):
@@ -52,11 +52,11 @@ def pull_s3_prefix_to_directory(uri: str, target: Path) -> None:
                 dest = target / rel
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 client.download_file(bucket, key, str(dest))
-                count += 1
+                downloaded_any = True
     except ClientError as e:
         raise RuntimeError(f"Failed to pull config from {uri!r}: {e}") from e
 
-    if count == 0:
+    if not downloaded_any:
         raise RuntimeError(
             f"No objects downloaded from {uri!r} (check bucket, prefix, and IAM). "
             f"Expected files such as defaults.yml under the prefix."

--- a/src/utils/s3_config_pull.py
+++ b/src/utils/s3_config_pull.py
@@ -1,0 +1,77 @@
+"""
+Download operator pipeline config from S3 into a local directory (runtime helper).
+
+Uses boto3 only (no AWS CLI). Intended for ECS/Fargate when
+``SPINE_CONFIG_S3_URI`` is set; ``docker/startup.sh`` invokes this before
+``python -m src.main``. When the variable is unset, startup skips this module.
+
+Unlike ``aws s3 sync --delete``, extra files already present under the target
+directory are not removed—only keys under the S3 prefix are written/overwritten.
+On Fargate ephemeral storage this is usually fine; if the image ships template
+files under ``config/`` that collide with your layout, sync into a dedicated
+empty path and set ``CONFIG_PATH`` to that path.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+from src.utils.s3_config_push import parse_s3_uri
+
+__all__ = ["pull_s3_prefix_to_directory"]
+
+
+def pull_s3_prefix_to_directory(uri: str, target: Path) -> None:
+    """
+    List all objects under the URI prefix and write them under ``target``,
+    preserving relative paths (same layout as a local ``CONFIG_PATH`` directory).
+    """
+    bucket, prefix = parse_s3_uri(uri)
+    if prefix and not prefix.endswith("/"):
+        prefix = prefix + "/"
+
+    client = boto3.client("s3")
+    paginator = client.get_paginator("list_objects_v2")
+    target = target.resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    try:
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("/"):
+                    continue
+                rel = key[len(prefix) :] if prefix else key
+                if not rel or rel.endswith("/"):
+                    continue
+                dest = target / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                client.download_file(bucket, key, str(dest))
+                count += 1
+    except ClientError as e:
+        raise RuntimeError(f"Failed to pull config from {uri!r}: {e}") from e
+
+    if count == 0:
+        raise RuntimeError(
+            f"No objects downloaded from {uri!r} (check bucket, prefix, and IAM). "
+            f"Expected files such as defaults.yml under the prefix."
+        )
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python -m src.utils.s3_config_pull <s3_uri> <target_dir>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    pull_s3_prefix_to_directory(sys.argv[1], Path(sys.argv[2]))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/s3_config_push.py
+++ b/src/utils/s3_config_push.py
@@ -1,0 +1,148 @@
+"""
+Upload operator pipeline config from disk to S3 (promotion / deployment helper).
+
+Skips templates and examples under ``config/``. Intended for one-off or CI use.
+
+At runtime on AWS, either set ``SPINE_CONFIG_S3_URI`` so ``docker/startup.sh``
+pulls via ``s3_config_pull`` (boto3), or populate ``CONFIG_PATH`` some other way
+(``aws s3 sync``, EFS, init container, etc.).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+import boto3
+from botocore.exceptions import ClientError
+
+__all__ = ["iter_operator_config_files", "parse_s3_uri", "push_config_to_s3"]
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_local_config_root(config_path: str | None = None) -> Path:
+    """
+    Match runtime ``CONFIG_PATH`` resolution: absolute paths as-is; otherwise
+    ``<repo>/config/<segment>`` (default segment ``.`` → ``config/``).
+    """
+    raw = (config_path if config_path is not None else os.environ.get("CONFIG_PATH", ".")).strip()
+    p = Path(raw)
+    if p.is_absolute():
+        return p.resolve()
+    return (_repository_root() / "config" / p).resolve()
+
+
+def parse_s3_uri(uri: str) -> Tuple[str, str]:
+    """Parse ``s3://bucket`` or ``s3://bucket/prefix`` into bucket and key prefix."""
+    u = uri.strip()
+    if not u.startswith("s3://"):
+        raise ValueError(f"S3 URI must start with s3://, got: {uri!r}")
+    rest = u[5:]
+    if not rest:
+        raise ValueError("S3 URI is missing bucket name")
+    if "/" in rest:
+        bucket, prefix = rest.split("/", 1)
+    else:
+        bucket, prefix = rest, ""
+    if not bucket:
+        raise ValueError("S3 URI has an empty bucket name")
+    return bucket, prefix
+
+
+def _normalize_key_prefix(prefix: str) -> str:
+    p = prefix.strip().strip("/")
+    return f"{p}/" if p else ""
+
+
+def iter_operator_config_files(config_root: Path) -> Iterator[Tuple[Path, str]]:
+    """
+    Yield ``(absolute_path, relative_posix_path)`` for files to upload.
+
+    Includes: ``defaults.yml``, ``sources/**/*.yml``, ``queries/**/*.sql``.
+    Excludes: ``examples/``, ``*.example.yml``, ``README.md``, ``.gitkeep``.
+    """
+    root = config_root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"Config root is not a directory: {root}")
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        if rel.startswith("examples/") or "/examples/" in rel:
+            continue
+        if path.name == "README.md":
+            continue
+        if path.name == ".gitkeep":
+            continue
+        if fnmatch(path.name, "*.example.yml"):
+            continue
+
+        if rel == "defaults.yml":
+            yield path, rel
+        elif rel.startswith("sources/") and rel.endswith(".yml"):
+            yield path, rel
+        elif rel.startswith("queries/") and rel.endswith(".sql"):
+            yield path, rel
+
+
+def push_config_to_s3(s3_uri: str, config_root: Path | None = None) -> int:
+    """
+    Upload operator files under ``config_root`` to ``s3_uri``.
+
+    Returns the number of objects uploaded. Raises ``RuntimeError`` if nothing
+    would be uploaded (empty tree or no matching files).
+    """
+    bucket, prefix = parse_s3_uri(s3_uri)
+    key_prefix = _normalize_key_prefix(prefix)
+    root = resolve_local_config_root() if config_root is None else Path(config_root).resolve()
+
+    pairs: list[Tuple[Path, str]] = list(iter_operator_config_files(root))
+    if not pairs:
+        raise RuntimeError(
+            f"No operator config files to upload under {root} "
+            f"(expected defaults.yml and/or sources/**/*.yml and/or queries/**/*.sql; "
+            f"excludes examples/, *.example.yml, README.md, .gitkeep)."
+        )
+
+    client = boto3.client("s3")
+    count = 0
+    try:
+        for local_path, rel in pairs:
+            key = f"{key_prefix}{rel}"
+            client.upload_file(str(local_path), bucket, key)
+            count += 1
+    except ClientError as e:
+        raise RuntimeError(f"Failed to upload config to {s3_uri!r}: {e}") from e
+
+    return count
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if len(args) < 1 or args[0] in ("-h", "--help"):
+        print(
+            "Usage: python -m src.utils.s3_config_push <s3_uri> [local_config_dir]\n\n"
+            "Upload defaults.yml, sources/**/*.yml, and queries/**/*.sql from the\n"
+            "given directory (default: CONFIG_PATH resolved like runtime, usually repo config/).",
+            file=sys.stderr if args and args[0] not in ("-h", "--help") else sys.stdout,
+        )
+        sys.exit(0 if args and args[0] in ("-h", "--help") else 1)
+
+    s3_uri = args[0]
+    local_override = Path(args[1]).resolve() if len(args) > 1 else None
+    n = push_config_to_s3(s3_uri, local_override)
+    print(f"Uploaded {n} file(s) to {s3_uri}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/s3_config_push.py
+++ b/src/utils/s3_config_push.py
@@ -21,6 +21,12 @@ from botocore.exceptions import ClientError
 
 __all__ = ["iter_operator_config_files", "parse_s3_uri", "push_config_to_s3"]
 
+_EXCLUDED_BASENAMES = {"README.md", ".gitkeep"}
+_INCLUDED_SUBTREES: tuple[tuple[str, str], ...] = (
+    ("sources/", ".yml"),
+    ("queries/", ".sql"),
+)
+
 
 def _repository_root() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -60,6 +66,20 @@ def _normalize_key_prefix(prefix: str) -> str:
     return f"{p}/" if p else ""
 
 
+def _is_excluded_config_path(rel: str, name: str) -> bool:
+    if rel.startswith("examples/") or "/examples/" in rel:
+        return True
+    if name in _EXCLUDED_BASENAMES:
+        return True
+    return fnmatch(name, "*.example.yml")
+
+
+def _is_included_config_path(rel: str) -> bool:
+    if rel == "defaults.yml":
+        return True
+    return any(rel.startswith(prefix) and rel.endswith(suffix) for prefix, suffix in _INCLUDED_SUBTREES)
+
+
 def iter_operator_config_files(config_root: Path) -> Iterator[Tuple[Path, str]]:
     """
     Yield ``(absolute_path, relative_posix_path)`` for files to upload.
@@ -78,20 +98,10 @@ def iter_operator_config_files(config_root: Path) -> Iterator[Tuple[Path, str]]:
             rel = path.relative_to(root).as_posix()
         except ValueError:
             continue
-        if rel.startswith("examples/") or "/examples/" in rel:
-            continue
-        if path.name == "README.md":
-            continue
-        if path.name == ".gitkeep":
-            continue
-        if fnmatch(path.name, "*.example.yml"):
+        if _is_excluded_config_path(rel, path.name):
             continue
 
-        if rel == "defaults.yml":
-            yield path, rel
-        elif rel.startswith("sources/") and rel.endswith(".yml"):
-            yield path, rel
-        elif rel.startswith("queries/") and rel.endswith(".sql"):
+        if _is_included_config_path(rel):
             yield path, rel
 
 

--- a/src/utils/s3_config_push.py
+++ b/src/utils/s3_config_push.py
@@ -77,7 +77,9 @@ def _is_excluded_config_path(rel: str, name: str) -> bool:
 def _is_included_config_path(rel: str) -> bool:
     if rel == "defaults.yml":
         return True
-    return any(rel.startswith(prefix) and rel.endswith(suffix) for prefix, suffix in _INCLUDED_SUBTREES)
+    return any(
+        rel.startswith(prefix) and rel.endswith(suffix) for prefix, suffix in _INCLUDED_SUBTREES
+    )
 
 
 def iter_operator_config_files(config_root: Path) -> Iterator[Tuple[Path, str]]:

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -158,8 +158,13 @@ class TestStructuredLogger:
 
         output = capture_logs.getvalue()
 
-        # Split output into lines and verify each level appears
-        lines = output.strip().split("\n")
+        # Lines from this logger only (other libraries may emit DEBUG to the same handler).
+        raw_lines = output.strip().split("\n")
+        lines = []
+        for line in raw_lines:
+            parts = line.split(" | ")
+            if len(parts) >= 4 and parts[2].strip() == "test":
+                lines.append(line)
         expected_levels = {
             "TRACE": "trace message",
             "DEBUG": "debug message",

--- a/tests/test_utils/test_s3_config_pull.py
+++ b/tests/test_utils/test_s3_config_pull.py
@@ -16,6 +16,7 @@ def test_pull_s3_prefix_to_directory_writes_files(tmp_path: Path) -> None:
         assert Prefix == "p/"
         yield {
             "Contents": [
+                {"Key": "p/"},
                 {"Key": "p/defaults.yml"},
                 {"Key": "p/sources/x.yml"},
             ]
@@ -33,6 +34,17 @@ def test_pull_s3_prefix_to_directory_writes_files(tmp_path: Path) -> None:
 
     assert (tmp_path / "defaults.yml").read_text() == "body-p/defaults.yml"
     assert (tmp_path / "sources" / "x.yml").read_text() == "body-p/sources/x.yml"
+
+
+def test_pull_s3_prefix_folder_marker_only_raises(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+    mock_client.get_paginator.return_value.paginate.return_value = iter(
+        [{"Contents": [{"Key": "prefix/"}]}]
+    )
+
+    with patch("src.utils.s3_config_pull.boto3.client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="No objects downloaded"):
+            pull_s3_prefix_to_directory("s3://b/prefix/", tmp_path)
 
 
 def test_pull_s3_prefix_empty_raises(tmp_path: Path) -> None:

--- a/tests/test_utils/test_s3_config_pull.py
+++ b/tests/test_utils/test_s3_config_pull.py
@@ -1,0 +1,44 @@
+"""Tests for optional S3 config pull (ECS/Fargate, boto3)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.utils.s3_config_pull import pull_s3_prefix_to_directory
+
+
+def test_pull_s3_prefix_to_directory_writes_files(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+
+    def paginate(Bucket, Prefix):
+        assert Bucket == "b"
+        assert Prefix == "p/"
+        yield {
+            "Contents": [
+                {"Key": "p/defaults.yml"},
+                {"Key": "p/sources/x.yml"},
+            ]
+        }
+
+    mock_client.get_paginator.return_value.paginate = paginate
+
+    def download_file(bucket, key, filename):
+        Path(filename).write_text(f"body-{key}", encoding="utf-8")
+
+    mock_client.download_file.side_effect = download_file
+
+    with patch("src.utils.s3_config_pull.boto3.client", return_value=mock_client):
+        pull_s3_prefix_to_directory("s3://b/p", tmp_path)
+
+    assert (tmp_path / "defaults.yml").read_text() == "body-p/defaults.yml"
+    assert (tmp_path / "sources" / "x.yml").read_text() == "body-p/sources/x.yml"
+
+
+def test_pull_s3_prefix_empty_raises(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+    mock_client.get_paginator.return_value.paginate.return_value = iter([{}])
+
+    with patch("src.utils.s3_config_pull.boto3.client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="No objects downloaded"):
+            pull_s3_prefix_to_directory("s3://b/prefix/", tmp_path)

--- a/tests/test_utils/test_s3_config_push.py
+++ b/tests/test_utils/test_s3_config_push.py
@@ -1,0 +1,89 @@
+"""Tests for S3 operator config push (promotion helper)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.utils.s3_config_push import (
+    iter_operator_config_files,
+    parse_s3_uri,
+    push_config_to_s3,
+)
+
+
+def test_parse_s3_uri_bucket_only() -> None:
+    assert parse_s3_uri("s3://my-bucket") == ("my-bucket", "")
+
+
+def test_parse_s3_uri_with_prefix() -> None:
+    assert parse_s3_uri("s3://my-bucket/spine/prod") == ("my-bucket", "spine/prod")
+
+
+def test_parse_s3_uri_strips_whitespace() -> None:
+    assert parse_s3_uri("  s3://b/p  ") == ("b", "p")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "http://bucket/key",
+        "bucket/key",
+        "s3://",
+        "",
+    ],
+)
+def test_parse_s3_uri_invalid(bad: str) -> None:
+    with pytest.raises(ValueError):
+        parse_s3_uri(bad)
+
+
+def test_iter_operator_config_files_includes_and_excludes(tmp_path: Path) -> None:
+    (tmp_path / "defaults.yml").write_text("d", encoding="utf-8")
+    (tmp_path / "defaults.example.yml").write_text("x", encoding="utf-8")
+    (tmp_path / "README.md").write_text("r", encoding="utf-8")
+    (tmp_path / "sources").mkdir()
+    (tmp_path / "sources" / "a.yml").write_text("a", encoding="utf-8")
+    (tmp_path / "sources" / "skip.txt").write_text("t", encoding="utf-8")
+    (tmp_path / "queries").mkdir()
+    (tmp_path / "queries" / "q.sql").write_text("q", encoding="utf-8")
+    examples = tmp_path / "examples"
+    examples.mkdir()
+    (examples / "e.yml").write_text("e", encoding="utf-8")
+    (tmp_path / "sources" / ".gitkeep").write_text("", encoding="utf-8")
+
+    rels = {rel for _, rel in iter_operator_config_files(tmp_path)}
+    assert rels == {"defaults.yml", "sources/a.yml", "queries/q.sql"}
+
+
+def test_push_config_to_s3_uploads(tmp_path: Path) -> None:
+    (tmp_path / "defaults.yml").write_text("x", encoding="utf-8")
+    mock_client = MagicMock()
+
+    with patch("src.utils.s3_config_push.boto3.client", return_value=mock_client):
+        n = push_config_to_s3("s3://my-bucket/prefix", tmp_path)
+
+    assert n == 1
+    mock_client.upload_file.assert_called_once()
+    call = mock_client.upload_file.call_args
+    assert call[0][0] == str(tmp_path / "defaults.yml")
+    assert call[0][1] == "my-bucket"
+    assert call[0][2] == "prefix/defaults.yml"
+
+
+def test_push_config_to_s3_bucket_only_prefix(tmp_path: Path) -> None:
+    (tmp_path / "defaults.yml").write_text("x", encoding="utf-8")
+    mock_client = MagicMock()
+
+    with patch("src.utils.s3_config_push.boto3.client", return_value=mock_client):
+        push_config_to_s3("s3://onlybucket", tmp_path)
+
+    assert mock_client.upload_file.call_args[0][2] == "defaults.yml"
+
+
+def test_push_config_to_s3_empty_raises(tmp_path: Path) -> None:
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "x.yml").write_text("x", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="No operator config files"):
+        push_config_to_s3("s3://b/p", tmp_path)

--- a/tests/test_utils/test_s3_config_push.py
+++ b/tests/test_utils/test_s3_config_push.py
@@ -50,6 +50,9 @@ def test_iter_operator_config_files_includes_and_excludes(tmp_path: Path) -> Non
     examples = tmp_path / "examples"
     examples.mkdir()
     (examples / "e.yml").write_text("e", encoding="utf-8")
+    nested_examples = tmp_path / "sources" / "examples"
+    nested_examples.mkdir()
+    (nested_examples / "nested.yml").write_text("n", encoding="utf-8")
     (tmp_path / "sources" / ".gitkeep").write_text("", encoding="utf-8")
 
     rels = {rel for _, rel in iter_operator_config_files(tmp_path)}


### PR DESCRIPTION
## Summary

Improves how operators run Spine on **AWS ECS/Fargate** with config in **S3**: documents the contract end-to-end, adds **boto3-only** promotion and runtime pull (no AWS CLI / sidecar / child image for the default path), and improves **observability** during bring-up.

### Changes

- **Docs:** ECS/S3 reference + deployment README links; AWS/IaC-neutral checklist; logging notes for Docker/ECS.
- **S3 config:** `s3_config_push` (promote to S3), `s3_config_pull` + optional `SPINE_CONFIG_S3_URI` in `startup.sh`; `.env.example` hints.
- **Observability:** `[spine-startup]` stderr lines; `ConfigLoader` DEBUG/WARNING for source file scan.
- **Tests:** push/pull unit tests; logger test isolated from py4j noise.

### Notes for operators

- Default **`ENTRYPOINT`** **`/startup.sh`** is enough for S3→disk when **`SPINE_CONFIG_S3_URI`** is set; task role needs **`s3:GetObject`** / **`s3:ListBucket`** on the config prefix. The **public image does not ship AWS CLI**; pull uses **boto3** already in the image.
- If possible, pin **`ghcr.io/victorlou/spine`** by **digest or `v*` tag**, not **`latest`**, for production.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
