### PR TITLE
Fix/image build and deploy simplification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ S3_INGESTION_BUCKET=your-ingestion-bucket-name
 # Promote local operator config to S3 (one-off / CI):
 #   python -m src.utils.s3_config_push s3://your-bucket/your-prefix/
 # [OPTIONAL] ECS/Fargate: pull operator config from S3 before the app starts (boto3 in
-# docker/startup.sh; no AWS CLI). Target is CONFIG_PATH if set, else /app/config.
+# docker/startup.sh; no AWS CLI). Target is CONFIG_PATH if set, else /config.
 # SPINE_CONFIG_S3_URI=s3://your-bucket/your-prefix/config/
 # See docs/deployment/ecs-s3-reference.md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,6 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     volumes:
-      - ./.env:/app/.env:ro
-      - ./config:/app/config:ro
+      - ./.env:/.env:ro
+      - ./config:/config:ro

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,7 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     SPARK_VERSION=3.5.0 \
-    HADOOP_VERSION=3.3.4 \
-    JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-
-# Java home will depend on the architecture of the machine (arm64 or amd64)
-# ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-arm64
+    HADOOP_VERSION=3.3.4
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,6 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     redis-server \
     redis-tools \
     && rm -rf /var/lib/apt/lists/*
+
+# Normalize JAVA_HOME to an architecture-agnostic path.
+RUN arch="$(dpkg --print-architecture)" && \
+    ln -s "/usr/lib/jvm/java-21-openjdk-${arch}" /usr/lib/jvm/java-21-openjdk
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
 
 # Configure Redis for in-memory only
 RUN sed -i 's/^save/# save/' /etc/redis/redis.conf && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,8 @@ RUN sed -i 's/^save/# save/' /etc/redis/redis.conf && \
     echo "save \"\"" >> /etc/redis/redis.conf && \
     echo "appendonly no" >> /etc/redis/redis.conf
 
-# Create app directory
-WORKDIR /app
+# Use filesystem root so runtime paths map directly to /config and /src
+WORKDIR /
 
 # Copy requirements first to leverage Docker cache
 COPY requirements.txt .
@@ -36,7 +36,7 @@ COPY src/ src/
 COPY config/ config/
 
 # Set Python path
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/
 
 # Create startup script
 COPY docker/startup.sh /startup.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ Docker-related configuration for Spine. The container includes Python 3.12, Java
 ## Prerequisites
 
 - Docker and Docker Compose
-- **`.env` at the repository root** (copy from `.env.example`) — keeps secrets out of `src/` and matches how the app loads dotenv files inside the container (`/app/.env`)
+- **`.env` at the repository root** (copy from `.env.example`) — keeps secrets out of `src/` and matches how the app loads dotenv files inside the container (`/.env`)
 - Pipeline config under `config/` (`defaults.yml` and `sources/`; copy from `config/defaults.example.yml` and `config/examples/`)
 
 ## Local Development
@@ -25,7 +25,7 @@ Docker-related configuration for Spine. The container includes Python 3.12, Java
    docker-compose up --build
    ```
 
-Docker Compose builds the image, mounts `.env` at `/app/.env`, mounts `config/`, and runs the pipeline.
+Docker Compose builds the image, mounts `.env` at `/.env`, mounts `config/`, and runs the pipeline.
 
 ### Option 2: Docker CLI
 
@@ -39,11 +39,11 @@ For more control (for example passing CLI args):
      -f docker/Dockerfile .
    ```
 
-2. **Run** (mount repo-root `.env` so `load_pipeline_dotenv()` can read `/app/.env`; mount `config/` the same way as Compose)
+2. **Run** (mount repo-root `.env` so `load_pipeline_dotenv()` can read `/.env`; mount `config/` the same way as Compose)
    ```bash
    docker run --rm \
-     -v "$(pwd)/.env:/app/.env:ro" \
-     -v "$(pwd)/config:/app/config:ro" \
+    -v "$(pwd)/.env:/.env:ro" \
+    -v "$(pwd)/config:/config:ro" \
      spine
    ```
 
@@ -55,18 +55,18 @@ For more control (for example passing CLI args):
 
 ```bash
 docker run --rm \
-  -v "$(pwd)/.env:/app/.env:ro" \
-  -v "$(pwd)/config:/app/config:ro" \
+  -v "$(pwd)/.env:/.env:ro" \
+  -v "$(pwd)/config:/config:ro" \
   spine --show-plan
 
 docker run --rm \
-  -v "$(pwd)/.env:/app/.env:ro" \
-  -v "$(pwd)/config:/app/config:ro" \
+  -v "$(pwd)/.env:/.env:ro" \
+  -v "$(pwd)/config:/config:ro" \
   spine --validate-only
 
 docker run --rm \
-  -v "$(pwd)/.env:/app/.env:ro" \
-  -v "$(pwd)/config:/app/config:ro" \
+  -v "$(pwd)/.env:/.env:ro" \
+  -v "$(pwd)/config:/config:ro" \
   spine --select jsonplaceholder --limit 5
 ```
 
@@ -75,6 +75,75 @@ docker run --rm \
 On pushes to **`main`** or **`v*` version tags**, GitHub Actions publishes an image to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)). Pull with your organization or user name and the repository name in lowercase, for example `docker pull ghcr.io/victorlou/spine:latest` or `docker pull ghcr.io/victorlou/spine:v1.0.0`.
 
 Runtime configuration in production should come from your orchestrator (secrets, task env), not from baking `.env` into the image.
+
+## External Operator Repo (published image)
+
+If you keep pipeline config in a separate operator repository, you can run the published image directly without cloning Spine source.
+
+### Recommended path mapping
+
+Spine resolves config from `/config` by default (`CONFIG_PATH=.`). So the simplest mapping is:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  --env-file .env \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+If you prefer mounting to `/config`, set `CONFIG_PATH=/config`:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  --env-file .env \
+  -e CONFIG_PATH=/config \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+### AWS credentials options
+
+Profile-based (`AWS_PROFILE` in `.env`):
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  -v "$HOME/.aws:/root/.aws:ro" \
+  --env-file .env \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+Before running with SSO profiles, authenticate on the host:
+
+```bash
+aws sso login --profile your_profile
+```
+
+Environment-key-based (no shared profile mount):
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  -e AWS_ACCESS_KEY_ID=... \
+  -e AWS_SECRET_ACCESS_KEY=... \
+  -e AWS_SESSION_TOKEN=... \
+  -e AWS_REGION=ap-southeast-2 \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+### Troubleshooting profile errors
+
+If you see `The config profile (...) could not be found`:
+
+1. Confirm the profile exists on host: `aws configure list-profiles`.
+2. Confirm host auth works: `aws sts get-caller-identity --profile your_profile`.
+3. Ensure `-v "$HOME/.aws:/root/.aws:ro"` is present when using `AWS_PROFILE`.
+4. Re-run `aws sso login --profile your_profile` if using SSO.
+5. Confirm region is set (`AWS_REGION` or profile region).
 
 ## Private PyPI (optional)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,6 +31,8 @@ Docker Compose builds the image, mounts `.env` at `/.env`, mounts `config/`, and
 
 For more control (for example passing CLI args):
 
+**Windows note:** run these commands in **PowerShell**. If you use Git Bash (MSYS), prefix with `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'` to avoid path conversion issues with mounts and `--entrypoint`.
+
 1. **Build**
    ```bash
    docker build \
@@ -116,11 +118,25 @@ docker run --rm \
   --select your_source
 ```
 
+Use `:ro` for static key-based profiles. For SSO profiles, use a writable mount so token cache can refresh:
+
+```bash
+-v "$HOME/.aws:/root/.aws"
+```
+
 Before running with SSO profiles, authenticate on the host:
 
 ```bash
 aws sso login --profile your_profile
 ```
+
+**Windows + Git Bash:** use:
+
+```bash
+MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker run ...
+```
+
+Without this, Git Bash may rewrite `/root/.aws` and break profile detection in the container.
 
 Environment-key-based (no shared profile mount):
 
@@ -141,9 +157,10 @@ If you see `The config profile (...) could not be found`:
 
 1. Confirm the profile exists on host: `aws configure list-profiles`.
 2. Confirm host auth works: `aws sts get-caller-identity --profile your_profile`.
-3. Ensure `-v "$HOME/.aws:/root/.aws:ro"` is present when using `AWS_PROFILE`.
-4. Re-run `aws sso login --profile your_profile` if using SSO.
-5. Confirm region is set (`AWS_REGION` or profile region).
+3. Ensure `.aws` is mounted at `/root/.aws` when using `AWS_PROFILE`.
+4. If using SSO profile, mount `.aws` writable (`-v "$HOME/.aws:/root/.aws"`), not `:ro`.
+5. Re-run `aws sso login --profile your_profile` if using SSO.
+6. Confirm region is set (`AWS_REGION` or profile region).
 
 ## Private PyPI (optional)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -94,16 +94,6 @@ docker run --rm \
   --select your_source
 ```
 
-If you prefer mounting to `/config`, set `CONFIG_PATH=/config`:
-
-```bash
-docker run --rm \
-  -v "$(pwd)/config:/config:ro" \
-  --env-file .env \
-  -e CONFIG_PATH=/config \
-  ghcr.io/victorlou/spine:vX.Y.Z \
-  --select your_source
-```
 
 ### AWS credentials options
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -74,7 +74,13 @@ docker run --rm \
 
 ## CI-built images
 
-On pushes to **`main`** or **`v*` version tags**, GitHub Actions publishes an image to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)). Pull with your organization or user name and the repository name in lowercase, for example `docker pull ghcr.io/victorlou/spine:latest` or `docker pull ghcr.io/victorlou/spine:v1.0.0`.
+On pushes to **`main`** or **`v*` version tags**, GitHub Actions publishes a multi-arch image (manifest list for `linux/amd64` and `linux/arm64`) to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)). Pull with your organization or user name and the repository name in lowercase, for example `docker pull ghcr.io/victorlou/spine:latest` or `docker pull ghcr.io/victorlou/spine:v1.0.0`.
+
+Verify published manifest platforms with:
+
+```bash
+docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
+```
 
 Runtime configuration in production should come from your orchestrator (secrets, task env), not from baking `.env` into the image.
 
@@ -164,7 +170,9 @@ If you add private wheels later, you can use a BuildKit secret and `pip.conf` du
 
 ## Apple Silicon (M1/M2)
 
-Use `--platform linux/amd64` when building to match common Linux/x86 deploy targets and avoid Java/Spark issues:
+Published GHCR images are multi-arch, so Apple Silicon hosts can pull `ghcr.io/victorlou/spine:*` directly without setting `--platform`.
+
+Use `--platform linux/amd64` only when you explicitly need to emulate x86_64 (for compatibility testing against amd64-only environments):
 
 ```bash
 docker build --platform linux/amd64 ...

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -16,7 +16,7 @@ echo "[spine-startup] Redis is ready." >&2
 
 # Optional: pull operator config from S3 (boto3; no AWS CLI). Off when unset.
 if [ -n "${SPINE_CONFIG_S3_URI:-}" ]; then
-  SYNC_TARGET="${CONFIG_PATH:-/app/config}"
+  SYNC_TARGET="${CONFIG_PATH:-/config}"
   mkdir -p "${SYNC_TARGET}"
   echo "[spine-startup] Pulling config from ${SPINE_CONFIG_S3_URI} -> ${SYNC_TARGET}" >&2
   python -m src.utils.s3_config_pull "${SPINE_CONFIG_S3_URI}" "${SYNC_TARGET}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,13 +22,19 @@ For full details (CLI args, Apple Silicon), see [docker/README.md](../docker/REA
 
 Linting and tests run on pushes and pull requests to **`dev`** and **`main`**, and on **version tag** pushes (`v*`), via [.github/workflows/ci.yml](../.github/workflows/ci.yml).
 
-The workflow **builds and pushes** a container image to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
+The workflow **builds and pushes** a multi-arch container image (manifest list for `linux/amd64` and `linux/arm64`) to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
 
 Requirements for the image job:
 
 - **Packages** permission for `GITHUB_TOKEN` (the workflow grants `packages: write` on the publish job only).
 
 Images are public or private according to your GitHub package visibility settings for the container package.
+
+After publish, you can verify manifest platforms with:
+
+```bash
+docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
+```
 
 ## Runtime configuration
 

--- a/docs/deployment/ecs-s3-reference.md
+++ b/docs/deployment/ecs-s3-reference.md
@@ -41,11 +41,11 @@ flowchart LR
 The public image **`ENTRYPOINT`** is `/startup.sh` (Redis, then `python -m src.main`). You do **not** need to override `command` or `entryPoint` if you use the built-in pull:
 
 1. Set **`SPINE_CONFIG_S3_URI`** to your operator prefix, for example `s3://<bucket-from-your-infra>/config/` (objects under that prefix should mirror `defaults.yml`, `sources/…`, `queries/…`).
-2. Optionally set **`CONFIG_PATH`** to an **absolute** directory inside the container (recommended for clarity). If unset, pull targets **`/app/config`**, which matches Spine’s default resolution for `CONFIG_PATH=.`.
+2. Optionally set **`CONFIG_PATH`** to an **absolute** directory inside the container (recommended for clarity). If unset, pull targets **`/config`**, which matches Spine’s default resolution for `CONFIG_PATH=.`.
 
 `startup.sh` runs `python -m src.utils.s3_config_pull` (boto3) before the app. The task **IAM role** must allow **`s3:GetObject`** on `prefix/*` and **`s3:ListBucket`** on the bucket (often prefix-scoped in the bucket policy).
 
-**Merge vs delete:** pull **downloads and overwrites** keys that exist in S3; it does **not** delete extra files already on disk under the target path (unlike `aws s3 sync --delete`). The image may ship template files under `/app/config`; if that is a problem, set `CONFIG_PATH` to a dedicated empty path (for example `/app/config-runtime`) and pull there instead.
+**Merge vs delete:** pull **downloads and overwrites** keys that exist in S3; it does **not** delete extra files already on disk under the target path (unlike `aws s3 sync --delete`). The image may ship template files under `/config`; if that is a problem, set `CONFIG_PATH` to a dedicated empty path (for example `/config-runtime`) and pull there instead.
 
 ---
 
@@ -85,6 +85,45 @@ Requires AWS credentials (profile or env) with **`s3:PutObject`** on `your-prefi
 
 ---
 
+## Local operator validation with published image
+
+From a fresh operator repository (config + `.env`, no Spine source checkout), run:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  --env-file .env \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+This uses the default config path contract (`/config`). If you mount elsewhere, set `CONFIG_PATH` accordingly (for example `-e CONFIG_PATH=/my-config`).
+
+```bash
+-e CONFIG_PATH=/config
+```
+
+Credential strategies:
+
+- **AWS profile**: set `AWS_PROFILE` in `.env` and mount `-v "$HOME/.aws:/root/.aws:ro"`.
+- **Direct env credentials**: set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, and `AWS_REGION`.
+
+For SSO profiles, login on host first:
+
+```bash
+aws sso login --profile your_profile
+```
+
+If you hit `The config profile (...) could not be found`, check profile name, mount presence, SSO freshness, and run:
+
+```bash
+aws sts get-caller-identity --profile your_profile
+```
+
+on the host to verify credentials before container startup.
+
+---
+
 ## Container image: GitHub Container Registry (GHCR)
 
 - **Public package:** ECS task definitions usually omit `repositoryCredentials`; any principal that can pull from `ghcr.io` can use the image reference.
@@ -110,7 +149,7 @@ Example URI (neutral): `s3://example-org-spine-config/prod/`
 | Variable | Required | Purpose |
 |----------|----------|---------|
 | `SPINE_CONFIG_S3_URI` | Optional | When set, `docker/startup.sh` pulls this prefix into the sync target **before** `python -m src.main` (boto3). When unset, no S3 read for config at start. |
-| `CONFIG_PATH` | Optional | **Absolute** path for config after pull. If unset while `SPINE_CONFIG_S3_URI` is set, pull uses **`/app/config`**. If both unset, Spine uses its normal default (`/app/config` via `CONFIG_PATH=.`). |
+| `CONFIG_PATH` | Optional | **Absolute** path for config after pull. If unset while `SPINE_CONFIG_S3_URI` is set, pull uses **`/config`**. If both unset, Spine uses its normal default (`/config` via `CONFIG_PATH=.`). |
 | `LOG_LEVEL` | Optional | Set to **`DEBUG`**, can be adjusted as defined in `src/utils/logger.py`.|
 | Other app secrets | As needed | Use `secrets` from AWS Secrets Manager or SSM Parameter Store as supported by ECS. |
 

--- a/docs/deployment/ecs-s3-reference.md
+++ b/docs/deployment/ecs-s3-reference.md
@@ -105,7 +105,8 @@ This uses the default config path contract (`/config`). If you mount elsewhere, 
 
 Credential strategies:
 
-- **AWS profile**: set `AWS_PROFILE` in `.env` and mount `-v "$HOME/.aws:/root/.aws:ro"`.
+- **AWS profile (static keys)**: set `AWS_PROFILE` in `.env` and mount `-v "$HOME/.aws:/root/.aws:ro"`.
+- **AWS profile (SSO)**: mount `-v "$HOME/.aws:/root/.aws"` (writable) so SSO cache refresh can write under `/root/.aws/sso/cache`.
 - **Direct env credentials**: set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, and `AWS_REGION`.
 
 For SSO profiles, login on host first:
@@ -121,6 +122,14 @@ aws sts get-caller-identity --profile your_profile
 ```
 
 on the host to verify credentials before container startup.
+
+For Windows operators using **Git Bash**, prefix `docker run` with:
+
+```bash
+MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'
+```
+
+or run the command from PowerShell. Git Bash path conversion can rewrite `/root/.aws` and `/config`, causing false profile-not-found errors even when host credentials are valid.
 
 ---
 

--- a/docs/deployment/ecs-s3-reference.md
+++ b/docs/deployment/ecs-s3-reference.md
@@ -99,15 +99,11 @@ docker run --rm \
 
 This uses the default config path contract (`/config`). If you mount elsewhere, set `CONFIG_PATH` accordingly (for example `-e CONFIG_PATH=/my-config`).
 
-```bash
--e CONFIG_PATH=/config
-```
-
 Credential strategies:
 
-- **AWS profile (static keys)**: set `AWS_PROFILE` in `.env` and mount `-v "$HOME/.aws:/root/.aws:ro"`.
-- **AWS profile (SSO)**: mount `-v "$HOME/.aws:/root/.aws"` (writable) so SSO cache refresh can write under `/root/.aws/sso/cache`.
-- **Direct env credentials**: set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, and `AWS_REGION`.
+- **AWS profile (static keys):** set `AWS_PROFILE` in `.env` and mount `-v "$HOME/.aws:/root/.aws:ro"`.
+- **AWS profile (SSO):** mount `-v "$HOME/.aws:/root/.aws"` (writable) so SSO cache refresh can write under `/root/.aws/sso/cache`.
+- **Direct env credentials:** set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, and `AWS_REGION`.
 
 For SSO profiles, login on host first:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --
 docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --select jsonplaceholder --limit 5
 ```
 
-**Apple Silicon (M1/M2)**: Add `--platform linux/amd64` to the build for compatibility.
+**Apple Silicon (M1/M2)**: Published GHCR images are multi-arch, so pull directly by tag. Add `--platform linux/amd64` only when you explicitly need x86_64 emulation.
 
 See [docker/README.md](../docker/README.md) for more Docker details.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,9 +41,9 @@ The easiest way to run the pipeline. Requires Docker and Docker Compose.
 docker build --platform linux/amd64 -t spine -f docker/Dockerfile .
 
 # Run with args
-docker run --rm -v "$(pwd)/.env:/app/.env:ro" -v "$(pwd)/config:/app/config:ro" spine --show-plan
-docker run --rm -v "$(pwd)/.env:/app/.env:ro" -v "$(pwd)/config:/app/config:ro" spine --validate-only
-docker run --rm -v "$(pwd)/.env:/app/.env:ro" -v "$(pwd)/config:/app/config:ro" spine --select jsonplaceholder --limit 5
+docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --show-plan
+docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --validate-only
+docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --select jsonplaceholder --limit 5
 ```
 
 **Apple Silicon (M1/M2)**: Add `--platform linux/amd64` to the build for compatibility.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,8 @@ The easiest way to run the pipeline. Requires Docker and Docker Compose.
 
 `docker-compose up` runs the default pipeline. For `--show-plan`, `--validate-only`, `--select`, etc., use `docker run`:
 
+On **Windows**, prefer running Docker commands in **PowerShell**. If you use Git Bash, prefix commands with `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'` so mount paths like `/config` are not rewritten.
+
 ```bash
 # Build the image first (or use an existing one from ghcr.io)
 docker build --platform linux/amd64 -t spine -f docker/Dockerfile .

--- a/src/utils/aws_credentials.py
+++ b/src/utils/aws_credentials.py
@@ -72,8 +72,19 @@ class AWSCredentialManager:
         except AWSError:
             raise
         except Exception as e:
+            hint = ""
+            err_text = str(e)
+            if "config profile" in err_text and "could not be found" in err_text:
+                hint = (
+                    " Hint: AWS_PROFILE is set but profile files are not available in the runtime. "
+                    "If running in Docker, mount $HOME/.aws:/root/.aws:ro (and run aws sso login first "
+                    "for SSO profiles), or provide AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY directly."
+                )
+            message = f"Failed to load AWS credentials: {e!s}"
+            if hint:
+                message = f"{message}. {hint.strip()}"
             raise AWSError(
-                message=f"Failed to load AWS credentials: {e!s}",
+                message=message,
                 operation="_load_credentials",
                 service="iam",
                 original_error=e,


### PR DESCRIPTION
## Summary

Improves operator local-testing with the published image, simplifies container path conventions to `/config`, clarifies AWS profile/SSO usage in Docker, and updates CI to publish multi-arch GHCR images for `linux/amd64` and `linux/arm64`.

### Changes

- **Operator Docker UX:** clearer external-repo run guidance, profile vs env-credential patterns, Windows/Git Bash notes, and troubleshooting for AWS profile/SSO issues.
- **Container path cleanup:** moved docs/runtime expectations from `/app/config` to `/config` and aligned Docker examples accordingly.
- **Startup/config visibility:** retained startup and config-load diagnostics for easier ECS/Docker debugging.
- **Multi-arch publishing:** CI now publishes manifest-backed GHCR images for amd64/arm64, and Dockerfile `JAVA_HOME` was made architecture-safe.
- **Docs:** deployment and Docker docs updated to reflect multi-arch `latest`, Apple Silicon expectations, and manifest inspection.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
