### PR TITLE
Feature/package cleanup and readme review

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,33 @@
+name: GHCR Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Package coordinates (lowercase for GHCR)
+        id: package
+        run: |
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          repository="$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')"
+          echo "owner=${owner}" >> "$GITHUB_OUTPUT"
+          echo "repository=${repository}" >> "$GITHUB_OUTPUT"
+
+      - name: Cleanup obsolete GHCR tags and manifests
+        uses: jenskeiner/ghcr-container-repository-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ steps.package.outputs.owner }}
+          repository: ${{ steps.package.outputs.repository }}
+          package: ${{ steps.package.outputs.repository }}
+          exclude-tags: ^(?:latest|v.*)$
+          keep-n-tagged: 10
+          keep-n-untagged: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Purpose
+
+Spine is a configuration-first ingestion framework. Treat it like production pipeline infrastructure, not a generic CRUD app or a place for source-specific one-off scripts.
+
+## Architecture Map
+
+- `src/config/`: config loading, validation, settings, and schema models
+- `src/handler/`: pipeline orchestration and resource execution flow
+- `src/planner/`: execution planning, dependency resolution, and staged runs
+- `src/service/`: source integrations such as REST, PostgreSQL, HANA, and Python SDK services
+- `src/parser/`: lightweight transformations over collected data
+- `src/collector/`: collection/storage strategy during extraction
+- `src/loader/`: destination loading such as S3
+- `config/`: operator-local YAML and SQL; committed files here are templates and examples
+
+## Working Rules
+
+- Prefer extending existing abstractions over adding source-specific branching in the main flow.
+- Keep concerns separated: auth, extraction, parsing, collection, loading, and planning should stay modular.
+- Preserve config-first behavior. New sources, resources, and tables should primarily be enabled through YAML under `config/`.
+- Fail early. If you change config shape or runtime assumptions, update validation in `src/config/` instead of relying on runtime errors.
+- Be explicit about production concerns: retries, logging, failure isolation, and backfill behavior should remain visible in code and docs.
+- Be critical of requested changes. Do not just implement the first workable idea if it adds avoidable coupling, weakens production behavior, or bloats the codebase.
+- Help operators get to the best solution, not just the fastest patch. Challenge assumptions when a request conflicts with maintainability, observability, or engineering best practices.
+
+## Configuration Discipline
+
+- Do not commit operator-local config, secrets, or internal-only endpoints. Public templates live in `config/defaults.example.yml` and `config/examples/`.
+- If you change config schema, also update the relevant examples and docs in `config/README.md` and `docs/configuration/`.
+- Respect `CONFIG_PATH` behavior in `src/config/settings.py` when changing config resolution.
+
+## Extending Spine
+
+- New auth behavior: extend the service/auth configuration model and validation together.
+- New destination: add a loader under `src/loader/`, register it in `src/loader/loader_factory.py`, and document any new config.
+- New source/service type: implement it under `src/service/`, wire it through the factory/config models, and avoid bypassing planner/handler flow.
+- New transformation or collection behavior should fit the existing parser/collector split rather than being embedded ad hoc in services.
+
+## Quality Bar
+
+- Run or preserve compatibility with `black`, `ruff`, `yamllint`, and `pytest`.
+- Keep logs useful for operations and debugging. Prefer structured, actionable messages over vague summaries.
+- Avoid hidden coupling across modules. If a change affects planning, config, and runtime behavior, update all three deliberately.
+- Be skeptical of convenience shortcuts that weaken validation, observability, or repeatability.
+- Prefer the smallest change that keeps the design clean. Avoid introducing new abstractions, flags, or special cases unless they clearly earn their keep.
+
+## Docs Expectations
+
+- Keep the `README.md` practical and honest. Personality is fine, but claims should match the implementation.
+- Use `docs/getting-started.md`, `docs/deployment.md`, and `docs/configuration/` as the source of truth for setup and behavior details.

--- a/README.md
+++ b/README.md
@@ -2,72 +2,37 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Spine is a developer-first ingestion layer that standardizes how data enters your platform.**
+**Spine is a configuration-first ingestion framework for teams that are tired of rebuilding the same ingestion logic for every new source, table, and destination.**
 
-It is not a no-code tool, nor a collection of prebuilt connectors.  
-Spine is an opinionated foundation for building, scaling, and maintaining ingestion pipelines through configuration, structure, and shared patterns.
+If your team keeps rewriting the same auth, retry, pagination, backfill, and loading logic for every new API or table, Spine is the part where that repetition stops getting a free pass.
+
+It is not a no-code product, a connector marketplace, or a black box. It is a modular runtime with one execution model, one config shape, and clear extension points for services, parsers, collectors, and loaders.
 
 ---
 
 ## Why Spine?
 
-Most data teams don’t struggle to *ingest data* — they struggle to do it **consistently, reliably, and at scale**.
+The hard part is usually not getting data out of one API once. The hard part is doing it the same way across many sources, keeping it reliable in production, and not creating a new snowflake every time somebody asks for one more table.
 
-Ingestion often becomes:
-- Dozens of one-off scripts
-- Inconsistent patterns across sources
-- Hard-to-maintain pipelines
-- No shared standards across teams
+Ingestion usually drifts into:
+- One-off scripts that only one person trusts
+- Different auth, retry, and pagination patterns per source
+- Config scattered across code, notebooks, and environment-specific glue
+- Pipelines that work until backfills, partial failures, or new destinations show up
 
-Spine solves this by introducing a **unified ingestion layer**:
+Spine gives you a shared modular shape for that work:
 
-> One way to define ingestion. One way to run it. One way to scale it.
-
----
-
-## What Spine Is (and isn’t)
-
-**Spine is:**
-- A **configuration-first ingestion system**
-- A **standardized entry point** into your data platform
-- A **developer-focused tool** designed for extensibility and control
-- A **foundation layer** that fits naturally into modern architectures (e.g. medallion)
-
-**Spine is not:**
-- A no-code ingestion tool
-- A managed connector platform
-- A black-box abstraction over your pipelines
-
-You build and extend it. Spine ensures everything follows the same structure.
-
----
-
-## Core Principles
-
-### 1. Standardization over ad hoc pipelines
-All ingestion follows the same structure — regardless of source.
-
-### 2. Configuration over code
-Pipelines are defined through YAML, not scattered scripts.
-
-### 3. Extensibility by design
-New sources, auth methods, and loaders can be added without breaking the system.
-
-### 4. Clear separation of concerns
-Authentication, extraction, transformation, and loading are modular and composable.
-
-### 5. Platform-first thinking
-Spine is not just a tool — it’s a **layer in your data platform**.
+> Define pipelines in YAML. Validate them up front. Build an execution plan. Run them with the same service, parser, and loader patterns every time.
 
 ---
 
 ## Features
 
-- **Modular architecture** — Authentication, fetching, transformation, and loading
-- **Configuration-driven** — YAML-based sources and endpoints
+- **Configuration-driven** — YAML-based sources, resources, defaults, and queries under `config/`
+- **Modular architecture** — Clear seams for services, handlers, parsers, collectors, and loaders
 - **Execution planning** — Dependency resolution and optimized execution order
-- **Resilient execution** — Retries and failure isolation per source/endpoint
-- **Extensible design** — Plug in new sources, loaders, and services
+- **Resilient execution** — Validation up front, retries, backfills, and failure isolation per source/resource
+- **Extensible design** — Add new sources, auth methods, loaders, and transformations without inventing a new flow
 - **Flexible inputs** — Path, query, body, dynamic parameters (dates, upstream data, etc.)
 
 ---
@@ -156,11 +121,12 @@ src/
 
 ---
 
-## Vision
+## When Spine Fits
 
-Spine aims to become the **standard foundation layer for ingestion in modern data platforms**.
+Spine is a good fit when you want ingestion work to stop fragmenting into source-specific scripts and conventions.
 
-As data ecosystems grow, ingestion should not be reinvented for every source.
-It should be structured, consistent, and scalable by design.
-
-Spine is that foundation.
+It is especially useful when:
+- You have multiple APIs, databases, or resources that should follow the same operational model
+- You want new tables or sources to be mostly a config and schema exercise, not a brand new code path
+- You need production concerns like retries, validation, backfills, and failure isolation to be built in from the start
+- You want a framework your team can extend deliberately, instead of a connector platform you eventually have to work around

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,6 +24,8 @@ Linting and tests run on pushes and pull requests to **`dev`** and **`main`**, a
 
 The workflow **builds and pushes** a multi-arch container image (manifest list for `linux/amd64` and `linux/arm64`) to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
 
+The package may show multiple digests for a single publish. That is expected for multi-arch images: one top-level manifest list plus child manifests for each architecture.
+
 Requirements for the image job:
 
 - **Packages** permission for `GITHUB_TOKEN` (the workflow grants `packages: write` on the publish job only).
@@ -35,6 +37,13 @@ After publish, you can verify manifest platforms with:
 ```bash
 docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
 ```
+
+A separate weekly cleanup workflow keeps the registry tidy while preserving multi-arch integrity:
+
+- keep `latest`
+- keep all `v*` tags
+- keep the 10 most recent SHA tags
+- delete untagged versions
 
 ## Runtime configuration
 


### PR DESCRIPTION
## Summary

This PR refreshes project guidance in two places:

- Reworked the top of `README.md` to be more engineer-to-engineer and less pitch-like.
- Simplified overlapping intro sections by removing repeated messaging and keeping a clearer structure (`Why Spine?` + `Features` + practical usage/docs).
- Added a root `AGENTS.md` with repo-specific standards for LLM agents (modular architecture, config discipline, production-grade expectations, and explicit guidance to be critical and avoid codebase bloat).

Additionally:
- Added a GHCR package cleanup routine in CI (`.github/workflows/ghcr-cleanup.yml`) to keep container registry artifacts tidy.

### Why

The previous docs were accurate but repetitive in the opening sections and a bit too formal/strategic in tone. This change makes the repo positioning clearer, more pragmatic, and easier for both engineers and coding agents to extend safely.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.