### PR TITLE
Main sync: Deploy simplification and documentation review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ S3_INGESTION_BUCKET=your-ingestion-bucket-name
 # Promote local operator config to S3 (one-off / CI):
 #   python -m src.utils.s3_config_push s3://your-bucket/your-prefix/
 # [OPTIONAL] ECS/Fargate: pull operator config from S3 before the app starts (boto3 in
-# docker/startup.sh; no AWS CLI). Target is CONFIG_PATH if set, else /app/config.
+# docker/startup.sh; no AWS CLI). Target is CONFIG_PATH if set, else /config.
 # SPINE_CONFIG_S3_URI=s3://your-bucket/your-prefix/config/
 # See docs/deployment/ecs-s3-reference.md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,6 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,33 @@
+name: GHCR Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Package coordinates (lowercase for GHCR)
+        id: package
+        run: |
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          repository="$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')"
+          echo "owner=${owner}" >> "$GITHUB_OUTPUT"
+          echo "repository=${repository}" >> "$GITHUB_OUTPUT"
+
+      - name: Cleanup obsolete GHCR tags and manifests
+        uses: jenskeiner/ghcr-container-repository-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ steps.package.outputs.owner }}
+          repository: ${{ steps.package.outputs.repository }}
+          package: ${{ steps.package.outputs.repository }}
+          exclude-tags: ^(?:latest|v.*)$
+          keep-n-tagged: 10
+          keep-n-untagged: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Purpose
+
+Spine is a configuration-first ingestion framework. Treat it like production pipeline infrastructure, not a generic CRUD app or a place for source-specific one-off scripts.
+
+## Architecture Map
+
+- `src/config/`: config loading, validation, settings, and schema models
+- `src/handler/`: pipeline orchestration and resource execution flow
+- `src/planner/`: execution planning, dependency resolution, and staged runs
+- `src/service/`: source integrations such as REST, PostgreSQL, HANA, and Python SDK services
+- `src/parser/`: lightweight transformations over collected data
+- `src/collector/`: collection/storage strategy during extraction
+- `src/loader/`: destination loading such as S3
+- `config/`: operator-local YAML and SQL; committed files here are templates and examples
+
+## Working Rules
+
+- Prefer extending existing abstractions over adding source-specific branching in the main flow.
+- Keep concerns separated: auth, extraction, parsing, collection, loading, and planning should stay modular.
+- Preserve config-first behavior. New sources, resources, and tables should primarily be enabled through YAML under `config/`.
+- Fail early. If you change config shape or runtime assumptions, update validation in `src/config/` instead of relying on runtime errors.
+- Be explicit about production concerns: retries, logging, failure isolation, and backfill behavior should remain visible in code and docs.
+- Be critical of requested changes. Do not just implement the first workable idea if it adds avoidable coupling, weakens production behavior, or bloats the codebase.
+- Help operators get to the best solution, not just the fastest patch. Challenge assumptions when a request conflicts with maintainability, observability, or engineering best practices.
+
+## Configuration Discipline
+
+- Do not commit operator-local config, secrets, or internal-only endpoints. Public templates live in `config/defaults.example.yml` and `config/examples/`.
+- If you change config schema, also update the relevant examples and docs in `config/README.md` and `docs/configuration/`.
+- Respect `CONFIG_PATH` behavior in `src/config/settings.py` when changing config resolution.
+
+## Extending Spine
+
+- New auth behavior: extend the service/auth configuration model and validation together.
+- New destination: add a loader under `src/loader/`, register it in `src/loader/loader_factory.py`, and document any new config.
+- New source/service type: implement it under `src/service/`, wire it through the factory/config models, and avoid bypassing planner/handler flow.
+- New transformation or collection behavior should fit the existing parser/collector split rather than being embedded ad hoc in services.
+
+## Quality Bar
+
+- Run or preserve compatibility with `black`, `ruff`, `yamllint`, and `pytest`.
+- Keep logs useful for operations and debugging. Prefer structured, actionable messages over vague summaries.
+- Avoid hidden coupling across modules. If a change affects planning, config, and runtime behavior, update all three deliberately.
+- Be skeptical of convenience shortcuts that weaken validation, observability, or repeatability.
+- Prefer the smallest change that keeps the design clean. Avoid introducing new abstractions, flags, or special cases unless they clearly earn their keep.
+
+## Docs Expectations
+
+- Keep the `README.md` practical and honest. Personality is fine, but claims should match the implementation.
+- Use `docs/getting-started.md`, `docs/deployment.md`, and `docs/configuration/` as the source of truth for setup and behavior details.

--- a/README.md
+++ b/README.md
@@ -2,72 +2,37 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Spine is a developer-first ingestion layer that standardizes how data enters your platform.**
+**Spine is a configuration-first ingestion framework for teams that are tired of rebuilding the same ingestion logic for every new source, table, and destination.**
 
-It is not a no-code tool, nor a collection of prebuilt connectors.  
-Spine is an opinionated foundation for building, scaling, and maintaining ingestion pipelines through configuration, structure, and shared patterns.
+If your team keeps rewriting the same auth, retry, pagination, backfill, and loading logic for every new API or table, Spine is the part where that repetition stops getting a free pass.
+
+It is not a no-code product, a connector marketplace, or a black box. It is a modular runtime with one execution model, one config shape, and clear extension points for services, parsers, collectors, and loaders.
 
 ---
 
 ## Why Spine?
 
-Most data teams don’t struggle to *ingest data* — they struggle to do it **consistently, reliably, and at scale**.
+The hard part is usually not getting data out of one API once. The hard part is doing it the same way across many sources, keeping it reliable in production, and not creating a new snowflake every time somebody asks for one more table.
 
-Ingestion often becomes:
-- Dozens of one-off scripts
-- Inconsistent patterns across sources
-- Hard-to-maintain pipelines
-- No shared standards across teams
+Ingestion usually drifts into:
+- One-off scripts that only one person trusts
+- Different auth, retry, and pagination patterns per source
+- Config scattered across code, notebooks, and environment-specific glue
+- Pipelines that work until backfills, partial failures, or new destinations show up
 
-Spine solves this by introducing a **unified ingestion layer**:
+Spine gives you a shared modular shape for that work:
 
-> One way to define ingestion. One way to run it. One way to scale it.
-
----
-
-## What Spine Is (and isn’t)
-
-**Spine is:**
-- A **configuration-first ingestion system**
-- A **standardized entry point** into your data platform
-- A **developer-focused tool** designed for extensibility and control
-- A **foundation layer** that fits naturally into modern architectures (e.g. medallion)
-
-**Spine is not:**
-- A no-code ingestion tool
-- A managed connector platform
-- A black-box abstraction over your pipelines
-
-You build and extend it. Spine ensures everything follows the same structure.
-
----
-
-## Core Principles
-
-### 1. Standardization over ad hoc pipelines
-All ingestion follows the same structure — regardless of source.
-
-### 2. Configuration over code
-Pipelines are defined through YAML, not scattered scripts.
-
-### 3. Extensibility by design
-New sources, auth methods, and loaders can be added without breaking the system.
-
-### 4. Clear separation of concerns
-Authentication, extraction, transformation, and loading are modular and composable.
-
-### 5. Platform-first thinking
-Spine is not just a tool — it’s a **layer in your data platform**.
+> Define pipelines in YAML. Validate them up front. Build an execution plan. Run them with the same service, parser, and loader patterns every time.
 
 ---
 
 ## Features
 
-- **Modular architecture** — Authentication, fetching, transformation, and loading
-- **Configuration-driven** — YAML-based sources and endpoints
+- **Configuration-driven** — YAML-based sources, resources, defaults, and queries under `config/`
+- **Modular architecture** — Clear seams for services, handlers, parsers, collectors, and loaders
 - **Execution planning** — Dependency resolution and optimized execution order
-- **Resilient execution** — Retries and failure isolation per source/endpoint
-- **Extensible design** — Plug in new sources, loaders, and services
+- **Resilient execution** — Validation up front, retries, backfills, and failure isolation per source/resource
+- **Extensible design** — Add new sources, auth methods, loaders, and transformations without inventing a new flow
 - **Flexible inputs** — Path, query, body, dynamic parameters (dates, upstream data, etc.)
 
 ---
@@ -156,11 +121,12 @@ src/
 
 ---
 
-## Vision
+## When Spine Fits
 
-Spine aims to become the **standard foundation layer for ingestion in modern data platforms**.
+Spine is a good fit when you want ingestion work to stop fragmenting into source-specific scripts and conventions.
 
-As data ecosystems grow, ingestion should not be reinvented for every source.
-It should be structured, consistent, and scalable by design.
-
-Spine is that foundation.
+It is especially useful when:
+- You have multiple APIs, databases, or resources that should follow the same operational model
+- You want new tables or sources to be mostly a config and schema exercise, not a brand new code path
+- You need production concerns like retries, validation, backfills, and failure isolation to be built in from the start
+- You want a framework your team can extend deliberately, instead of a connector platform you eventually have to work around

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     volumes:
-      - ./.env:/app/.env:ro
-      - ./config:/app/config:ro
+      - ./.env:/.env:ro
+      - ./config:/config:ro

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,7 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     SPARK_VERSION=3.5.0 \
-    HADOOP_VERSION=3.3.4 \
-    JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-
-# Java home will depend on the architecture of the machine (arm64 or amd64)
-# ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-arm64
+    HADOOP_VERSION=3.3.4
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -18,13 +14,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     redis-tools \
     && rm -rf /var/lib/apt/lists/*
 
+# Normalize JAVA_HOME to an architecture-agnostic path.
+RUN arch="$(dpkg --print-architecture)" && \
+    ln -s "/usr/lib/jvm/java-21-openjdk-${arch}" /usr/lib/jvm/java-21-openjdk
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+
 # Configure Redis for in-memory only
 RUN sed -i 's/^save/# save/' /etc/redis/redis.conf && \
     echo "save \"\"" >> /etc/redis/redis.conf && \
     echo "appendonly no" >> /etc/redis/redis.conf
 
-# Create app directory
-WORKDIR /app
+# Use filesystem root so runtime paths map directly to /config and /src
+WORKDIR /
 
 # Copy requirements first to leverage Docker cache
 COPY requirements.txt .
@@ -36,7 +38,7 @@ COPY src/ src/
 COPY config/ config/
 
 # Set Python path
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/
 
 # Create startup script
 COPY docker/startup.sh /startup.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ Docker-related configuration for Spine. The container includes Python 3.12, Java
 ## Prerequisites
 
 - Docker and Docker Compose
-- **`.env` at the repository root** (copy from `.env.example`) — keeps secrets out of `src/` and matches how the app loads dotenv files inside the container (`/app/.env`)
+- **`.env` at the repository root** (copy from `.env.example`) — keeps secrets out of `src/` and matches how the app loads dotenv files inside the container (`/.env`)
 - Pipeline config under `config/` (`defaults.yml` and `sources/`; copy from `config/defaults.example.yml` and `config/examples/`)
 
 ## Local Development
@@ -25,11 +25,13 @@ Docker-related configuration for Spine. The container includes Python 3.12, Java
    docker-compose up --build
    ```
 
-Docker Compose builds the image, mounts `.env` at `/app/.env`, mounts `config/`, and runs the pipeline.
+Docker Compose builds the image, mounts `.env` at `/.env`, mounts `config/`, and runs the pipeline.
 
 ### Option 2: Docker CLI
 
 For more control (for example passing CLI args):
+
+**Windows note:** run these commands in **PowerShell**. If you use Git Bash (MSYS), prefix with `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'` to avoid path conversion issues with mounts and `--entrypoint`.
 
 1. **Build**
    ```bash
@@ -39,11 +41,11 @@ For more control (for example passing CLI args):
      -f docker/Dockerfile .
    ```
 
-2. **Run** (mount repo-root `.env` so `load_pipeline_dotenv()` can read `/app/.env`; mount `config/` the same way as Compose)
+2. **Run** (mount repo-root `.env` so `load_pipeline_dotenv()` can read `/.env`; mount `config/` the same way as Compose)
    ```bash
    docker run --rm \
-     -v "$(pwd)/.env:/app/.env:ro" \
-     -v "$(pwd)/config:/app/config:ro" \
+    -v "$(pwd)/.env:/.env:ro" \
+    -v "$(pwd)/config:/config:ro" \
      spine
    ```
 
@@ -55,26 +57,106 @@ For more control (for example passing CLI args):
 
 ```bash
 docker run --rm \
-  -v "$(pwd)/.env:/app/.env:ro" \
-  -v "$(pwd)/config:/app/config:ro" \
+  -v "$(pwd)/.env:/.env:ro" \
+  -v "$(pwd)/config:/config:ro" \
   spine --show-plan
 
 docker run --rm \
-  -v "$(pwd)/.env:/app/.env:ro" \
-  -v "$(pwd)/config:/app/config:ro" \
+  -v "$(pwd)/.env:/.env:ro" \
+  -v "$(pwd)/config:/config:ro" \
   spine --validate-only
 
 docker run --rm \
-  -v "$(pwd)/.env:/app/.env:ro" \
-  -v "$(pwd)/config:/app/config:ro" \
+  -v "$(pwd)/.env:/.env:ro" \
+  -v "$(pwd)/config:/config:ro" \
   spine --select jsonplaceholder --limit 5
 ```
 
 ## CI-built images
 
-On pushes to **`main`** or **`v*` version tags**, GitHub Actions publishes an image to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)). Pull with your organization or user name and the repository name in lowercase, for example `docker pull ghcr.io/victorlou/spine:latest` or `docker pull ghcr.io/victorlou/spine:v1.0.0`.
+On pushes to **`main`** or **`v*` version tags**, GitHub Actions publishes a multi-arch image (manifest list for `linux/amd64` and `linux/arm64`) to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)). Pull with your organization or user name and the repository name in lowercase, for example `docker pull ghcr.io/victorlou/spine:latest` or `docker pull ghcr.io/victorlou/spine:v1.0.0`.
+
+Verify published manifest platforms with:
+
+```bash
+docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
+```
 
 Runtime configuration in production should come from your orchestrator (secrets, task env), not from baking `.env` into the image.
+
+## External Operator Repo (published image)
+
+If you keep pipeline config in a separate operator repository, you can run the published image directly without cloning Spine source.
+
+### Recommended path mapping
+
+Spine resolves config from `/config` by default (`CONFIG_PATH=.`). So the simplest mapping is:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  --env-file .env \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+
+### AWS credentials options
+
+Profile-based (`AWS_PROFILE` in `.env`):
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  -v "$HOME/.aws:/root/.aws:ro" \
+  --env-file .env \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+Use `:ro` for static key-based profiles. For SSO profiles, use a writable mount so token cache can refresh:
+
+```bash
+-v "$HOME/.aws:/root/.aws"
+```
+
+Before running with SSO profiles, authenticate on the host:
+
+```bash
+aws sso login --profile your_profile
+```
+
+**Windows + Git Bash:** use:
+
+```bash
+MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker run ...
+```
+
+Without this, Git Bash may rewrite `/root/.aws` and break profile detection in the container.
+
+Environment-key-based (no shared profile mount):
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  -e AWS_ACCESS_KEY_ID=... \
+  -e AWS_SECRET_ACCESS_KEY=... \
+  -e AWS_SESSION_TOKEN=... \
+  -e AWS_REGION=ap-southeast-2 \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+### Troubleshooting profile errors
+
+If you see `The config profile (...) could not be found`:
+
+1. Confirm the profile exists on host: `aws configure list-profiles`.
+2. Confirm host auth works: `aws sts get-caller-identity --profile your_profile`.
+3. Ensure `.aws` is mounted at `/root/.aws` when using `AWS_PROFILE`.
+4. If using SSO profile, mount `.aws` writable (`-v "$HOME/.aws:/root/.aws"`), not `:ro`.
+5. Re-run `aws sso login --profile your_profile` if using SSO.
+6. Confirm region is set (`AWS_REGION` or profile region).
 
 ## Private PyPI (optional)
 
@@ -88,7 +170,9 @@ If you add private wheels later, you can use a BuildKit secret and `pip.conf` du
 
 ## Apple Silicon (M1/M2)
 
-Use `--platform linux/amd64` when building to match common Linux/x86 deploy targets and avoid Java/Spark issues:
+Published GHCR images are multi-arch, so Apple Silicon hosts can pull `ghcr.io/victorlou/spine:*` directly without setting `--platform`.
+
+Use `--platform linux/amd64` only when you explicitly need to emulate x86_64 (for compatibility testing against amd64-only environments):
 
 ```bash
 docker build --platform linux/amd64 ...

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -16,7 +16,7 @@ echo "[spine-startup] Redis is ready." >&2
 
 # Optional: pull operator config from S3 (boto3; no AWS CLI). Off when unset.
 if [ -n "${SPINE_CONFIG_S3_URI:-}" ]; then
-  SYNC_TARGET="${CONFIG_PATH:-/app/config}"
+  SYNC_TARGET="${CONFIG_PATH:-/config}"
   mkdir -p "${SYNC_TARGET}"
   echo "[spine-startup] Pulling config from ${SPINE_CONFIG_S3_URI} -> ${SYNC_TARGET}" >&2
   python -m src.utils.s3_config_pull "${SPINE_CONFIG_S3_URI}" "${SYNC_TARGET}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,6 +24,8 @@ Linting and tests run on pushes and pull requests to **`dev`** and **`main`**, a
 
 The workflow **builds and pushes** a multi-arch container image (manifest list for `linux/amd64` and `linux/arm64`) to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
 
+The package may show multiple digests for a single publish. That is expected for multi-arch images: one top-level manifest list plus child manifests for each architecture.
+
 Requirements for the image job:
 
 - **Packages** permission for `GITHUB_TOKEN` (the workflow grants `packages: write` on the publish job only).
@@ -35,6 +37,13 @@ After publish, you can verify manifest platforms with:
 ```bash
 docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
 ```
+
+A separate weekly cleanup workflow keeps the registry tidy while preserving multi-arch integrity:
+
+- keep `latest`
+- keep all `v*` tags
+- keep the 10 most recent SHA tags
+- delete untagged versions
 
 ## Runtime configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,13 +22,19 @@ For full details (CLI args, Apple Silicon), see [docker/README.md](../docker/REA
 
 Linting and tests run on pushes and pull requests to **`dev`** and **`main`**, and on **version tag** pushes (`v*`), via [.github/workflows/ci.yml](../.github/workflows/ci.yml).
 
-The workflow **builds and pushes** a container image to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
+The workflow **builds and pushes** a multi-arch container image (manifest list for `linux/amd64` and `linux/arm64`) to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
 
 Requirements for the image job:
 
 - **Packages** permission for `GITHUB_TOKEN` (the workflow grants `packages: write` on the publish job only).
 
 Images are public or private according to your GitHub package visibility settings for the container package.
+
+After publish, you can verify manifest platforms with:
+
+```bash
+docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
+```
 
 ## Runtime configuration
 

--- a/docs/deployment/ecs-s3-reference.md
+++ b/docs/deployment/ecs-s3-reference.md
@@ -41,11 +41,11 @@ flowchart LR
 The public image **`ENTRYPOINT`** is `/startup.sh` (Redis, then `python -m src.main`). You do **not** need to override `command` or `entryPoint` if you use the built-in pull:
 
 1. Set **`SPINE_CONFIG_S3_URI`** to your operator prefix, for example `s3://<bucket-from-your-infra>/config/` (objects under that prefix should mirror `defaults.yml`, `sources/…`, `queries/…`).
-2. Optionally set **`CONFIG_PATH`** to an **absolute** directory inside the container (recommended for clarity). If unset, pull targets **`/app/config`**, which matches Spine’s default resolution for `CONFIG_PATH=.`.
+2. Optionally set **`CONFIG_PATH`** to an **absolute** directory inside the container (recommended for clarity). If unset, pull targets **`/config`**, which matches Spine’s default resolution for `CONFIG_PATH=.`.
 
 `startup.sh` runs `python -m src.utils.s3_config_pull` (boto3) before the app. The task **IAM role** must allow **`s3:GetObject`** on `prefix/*` and **`s3:ListBucket`** on the bucket (often prefix-scoped in the bucket policy).
 
-**Merge vs delete:** pull **downloads and overwrites** keys that exist in S3; it does **not** delete extra files already on disk under the target path (unlike `aws s3 sync --delete`). The image may ship template files under `/app/config`; if that is a problem, set `CONFIG_PATH` to a dedicated empty path (for example `/app/config-runtime`) and pull there instead.
+**Merge vs delete:** pull **downloads and overwrites** keys that exist in S3; it does **not** delete extra files already on disk under the target path (unlike `aws s3 sync --delete`). The image may ship template files under `/config`; if that is a problem, set `CONFIG_PATH` to a dedicated empty path (for example `/config-runtime`) and pull there instead.
 
 ---
 
@@ -85,6 +85,50 @@ Requires AWS credentials (profile or env) with **`s3:PutObject`** on `your-prefi
 
 ---
 
+## Local operator validation with published image
+
+From a fresh operator repository (config + `.env`, no Spine source checkout), run:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config:/config:ro" \
+  --env-file .env \
+  ghcr.io/victorlou/spine:vX.Y.Z \
+  --select your_source
+```
+
+This uses the default config path contract (`/config`). If you mount elsewhere, set `CONFIG_PATH` accordingly (for example `-e CONFIG_PATH=/my-config`).
+
+Credential strategies:
+
+- **AWS profile (static keys):** set `AWS_PROFILE` in `.env` and mount `-v "$HOME/.aws:/root/.aws:ro"`.
+- **AWS profile (SSO):** mount `-v "$HOME/.aws:/root/.aws"` (writable) so SSO cache refresh can write under `/root/.aws/sso/cache`.
+- **Direct env credentials:** set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, and `AWS_REGION`.
+
+For SSO profiles, login on host first:
+
+```bash
+aws sso login --profile your_profile
+```
+
+If you hit `The config profile (...) could not be found`, check profile name, mount presence, SSO freshness, and run:
+
+```bash
+aws sts get-caller-identity --profile your_profile
+```
+
+on the host to verify credentials before container startup.
+
+For Windows operators using **Git Bash**, prefix `docker run` with:
+
+```bash
+MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'
+```
+
+or run the command from PowerShell. Git Bash path conversion can rewrite `/root/.aws` and `/config`, causing false profile-not-found errors even when host credentials are valid.
+
+---
+
 ## Container image: GitHub Container Registry (GHCR)
 
 - **Public package:** ECS task definitions usually omit `repositoryCredentials`; any principal that can pull from `ghcr.io` can use the image reference.
@@ -110,7 +154,7 @@ Example URI (neutral): `s3://example-org-spine-config/prod/`
 | Variable | Required | Purpose |
 |----------|----------|---------|
 | `SPINE_CONFIG_S3_URI` | Optional | When set, `docker/startup.sh` pulls this prefix into the sync target **before** `python -m src.main` (boto3). When unset, no S3 read for config at start. |
-| `CONFIG_PATH` | Optional | **Absolute** path for config after pull. If unset while `SPINE_CONFIG_S3_URI` is set, pull uses **`/app/config`**. If both unset, Spine uses its normal default (`/app/config` via `CONFIG_PATH=.`). |
+| `CONFIG_PATH` | Optional | **Absolute** path for config after pull. If unset while `SPINE_CONFIG_S3_URI` is set, pull uses **`/config`**. If both unset, Spine uses its normal default (`/config` via `CONFIG_PATH=.`). |
 | `LOG_LEVEL` | Optional | Set to **`DEBUG`**, can be adjusted as defined in `src/utils/logger.py`.|
 | Other app secrets | As needed | Use `secrets` from AWS Secrets Manager or SSM Parameter Store as supported by ECS. |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,17 +36,19 @@ The easiest way to run the pipeline. Requires Docker and Docker Compose.
 
 `docker-compose up` runs the default pipeline. For `--show-plan`, `--validate-only`, `--select`, etc., use `docker run`:
 
+On **Windows**, prefer running Docker commands in **PowerShell**. If you use Git Bash, prefix commands with `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'` so mount paths like `/config` are not rewritten.
+
 ```bash
 # Build the image first (or use an existing one from ghcr.io)
 docker build --platform linux/amd64 -t spine -f docker/Dockerfile .
 
 # Run with args
-docker run --rm -v "$(pwd)/.env:/app/.env:ro" -v "$(pwd)/config:/app/config:ro" spine --show-plan
-docker run --rm -v "$(pwd)/.env:/app/.env:ro" -v "$(pwd)/config:/app/config:ro" spine --validate-only
-docker run --rm -v "$(pwd)/.env:/app/.env:ro" -v "$(pwd)/config:/app/config:ro" spine --select jsonplaceholder --limit 5
+docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --show-plan
+docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --validate-only
+docker run --rm -v "$(pwd)/.env:/.env:ro" -v "$(pwd)/config:/config:ro" spine --select jsonplaceholder --limit 5
 ```
 
-**Apple Silicon (M1/M2)**: Add `--platform linux/amd64` to the build for compatibility.
+**Apple Silicon (M1/M2)**: Published GHCR images are multi-arch, so pull directly by tag. Add `--platform linux/amd64` only when you explicitly need x86_64 emulation.
 
 See [docker/README.md](../docker/README.md) for more Docker details.
 

--- a/src/utils/aws_credentials.py
+++ b/src/utils/aws_credentials.py
@@ -72,8 +72,19 @@ class AWSCredentialManager:
         except AWSError:
             raise
         except Exception as e:
+            hint = ""
+            err_text = str(e)
+            if "config profile" in err_text and "could not be found" in err_text:
+                hint = (
+                    " Hint: AWS_PROFILE is set but profile files are not available in the runtime. "
+                    "If running in Docker, mount $HOME/.aws:/root/.aws:ro (and run aws sso login first "
+                    "for SSO profiles), or provide AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY directly."
+                )
+            message = f"Failed to load AWS credentials: {e!s}"
+            if hint:
+                message = f"{message}. {hint.strip()}"
             raise AWSError(
-                message=f"Failed to load AWS credentials: {e!s}",
+                message=message,
                 operation="_load_credentials",
                 service="iam",
                 original_error=e,


### PR DESCRIPTION
## Summary

- Container Paths: Moved runtime docs to /config and updated Docker examples.
- Multi-Arch: CI now publishes multi-arch GHCR images (amd64/arm64) with updated JAVA_HOME.
- README: Reworked intro to be more engineer-focused and concise.
- AGENTS.md: Added repo standards for LLM agents (modular architecture, config discipline).
- CI: Added GHCR package cleanup task (ghcr-cleanup.yml).

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
