### PR TITLE
Fix/issue 11 database request contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,13 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 
 - Keep the `README.md` practical and honest. Personality is fine, but claims should match the implementation.
 - Use `docs/getting-started.md`, `docs/deployment.md`, and `docs/configuration/` as the source of truth for setup and behavior details.
+
+## GitHub issues
+
+When work is tracked in a GitHub issue, treat the issue body as the contract.
+
+- **Before coding** — Read **Problem statement**, **Scope** / **Out of scope**, and **Done when**. Stay inside that boundary. If the issue is wrong, incomplete, or you need a wider change, **suggest** comment text for the operator to post on the issue (or propose splitting a follow-up issue) instead of folding extra requirements into one PR.
+- **Traceability** — Assistants should **not** open or edit pull requests or issues on GitHub via MCP/API unless the operator explicitly asks for that. Default: propose a **Related** line (and the rest of the PR description) the operator can paste when they open the PR, following [`.github/pull_request_template.md`](.github/pull_request_template.md): e.g. `Fixes #N` if merge should close the issue, or `Refs #N` for partial or exploratory work.
+- **Operator-visible changes** — If the issue changes YAML shape, defaults, or runtime behavior operators rely on, remind them to update `docs/configuration/` (and examples under `config/` where applicable) in the same change set, not as a silent follow-up.
+
+For filing issues, use [`.github/ISSUE_DRAFT_STANDARD.md`](.github/ISSUE_DRAFT_STANDARD.md) and the **Engineering task** template under [`.github/ISSUE_TEMPLATE/engineering_task.md`](.github/ISSUE_TEMPLATE/engineering_task.md) so scope and acceptance criteria stay consistent with how implementers work.

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -5,6 +5,7 @@
 - [Configuration Layout](#configuration-layout)
 - [Main Structure](#main-structure)
 - [Configuration Topics](#configuration-topics)
+- [Database resources and request contexts](#database-resources-and-request-contexts)
 
 ## Configuration Layout
 
@@ -71,3 +72,11 @@ sources:
 | [Auth](auth.md) | OAuth JWT, bearer token, API key |
 | [Transformations](transformations.md) | add_column, add_column_from_request, ensure_param_values_in_output |
 | **PostgreSQL / HANA** | `type: postgresql` or `type: hana` with JDBC-style connection fields. PostgreSQL requires `database`. For HANA, `database` is the **tenant database name** passed to hdbcli as `databaseName` (must match a real tenant; errors such as `database '…' not connected` usually mean the wrong name). It can be omitted when your `host:port` already targets a single tenant. See [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml). |
+
+### Database resources and request contexts
+
+For PostgreSQL and HANA resources, Spine reads the configured table (or `database_select_query`) **once per resource run**, regardless of how many [request contexts](parameters.md) batching or backfill produces. Request contexts still drive REST/SDK calls; they do **not** cause repeated `SELECT`-style extracts of the same static query.
+
+- **Why:** The handler does not substitute per-context values into `database_schema`, `database_table`, or `database_select_query` today. Running one extract avoids duplicate database load and avoids duplicating identical rows in Spark when `request_contexts` has length greater than one.
+- **Transformations:** When transformations run on database-sourced DataFrames, the request context passed in is taken from **`request_contexts[0]`** (first context after expansion). Design batch inputs and transforms accordingly.
+- **Scoping data:** To limit which rows are read, set **`database_select_query`** to the SQL you need (static query in YAML). Per-context or templated SQL is not supported yet; if you need different extracts per context, split into separate resources or follow future docs for SQL templating.

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -1826,16 +1826,6 @@ class DynamicHandler(BaseHandler):
             )
             extract_invocations = 1
 
-            self.logger.info(
-                "Database extract dataframe built",
-                extra_fields={
-                    "resource_name": resource_meta.resource_name,
-                    "source": resource_meta.source_name,
-                    "request_context_count": request_context_count,
-                    "extract_invocations": extract_invocations,
-                },
-            )
-
             if configured_fields:
                 fields = configured_fields
             else:
@@ -1860,6 +1850,15 @@ class DynamicHandler(BaseHandler):
                         },
                     )
                 select_cols.append(col(f.source).cast("string").alias(f.name))
+            self.logger.info(
+                "Database extract dataframe built",
+                extra_fields={
+                    "resource_name": resource_meta.resource_name,
+                    "source": resource_meta.source_name,
+                    "request_context_count": request_context_count,
+                    "extract_invocations": extract_invocations,
+                },
+            )
             return df.select(*select_cols)
         finally:
             service.close()

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -1792,55 +1792,75 @@ class DynamicHandler(BaseHandler):
 
         When ``fields`` is omitted or empty, output columns match the extract (name and source
         equal each result column), same idea as REST resources without an explicit field list.
+
+        The physical table (or ``database_select_query``) is resolved once per resource run:
+        ``extract_table`` is not repeated per ``request_contexts`` entry. Batch-expanded contexts
+        affect REST/SDK requests, not multiple JDBC reads of the same query. Transformations
+        for database resources still receive ``request_contexts[0]`` as request context.
         """
         resource_config = resource_meta.config
         configured_fields = resource_config.fields
         schema = str(resource_config.database_schema).strip()
         table = str(resource_config.database_table).strip()
-        all_df: Optional[DataFrame] = None
+        request_context_count = len(request_contexts)
+        extract_invocations = 0
         service.connect()
-        inferred_schema_logged = False
         try:
-            for _ctx in request_contexts:
-                df = service.extract_table(
-                    schema=schema,
-                    table=table,
-                    select_query=resource_config.database_select_query,
-                    spark_session=self.spark,
+            if not request_contexts:
+                self.logger.debug(
+                    "Database extract skipped: no request contexts",
+                    extra_fields={
+                        "resource_name": resource_meta.resource_name,
+                        "source": resource_meta.source_name,
+                        "request_context_count": request_context_count,
+                        "extract_invocations": extract_invocations,
+                    },
                 )
-                if configured_fields:
-                    fields = configured_fields
-                else:
-                    fields = [SchemaField(name=c, source=c) for c in df.columns]
-                    if not inferred_schema_logged:
-                        self.logger.info(
-                            "Database extract has no configured fields; inferring output columns from extract",
-                            extra_fields={
-                                "resource_name": resource_meta.resource_name,
-                                "source": resource_meta.source_name,
-                                "inferred_columns": list(df.columns),
-                            },
-                        )
-                        inferred_schema_logged = True
-                select_cols = []
-                for f in fields:
-                    if f.source not in df.columns:
-                        raise HandlerError(
-                            f"Configured field source {f.source!r} not in extract columns: {list(df.columns)}",
-                            operation="process_resource",
-                            details={
-                                "resource_name": resource_meta.resource_name,
-                                "source": resource_meta.source_name,
-                            },
-                        )
-                    select_cols.append(col(f.source).cast("string").alias(f.name))
-                batch_df = df.select(*select_cols)
-                all_df = (
-                    batch_df
-                    if all_df is None
-                    else all_df.unionByName(batch_df, allowMissingColumns=True)
+                return None
+
+            df = service.extract_table(
+                schema=schema,
+                table=table,
+                select_query=resource_config.database_select_query,
+                spark_session=self.spark,
+            )
+            extract_invocations = 1
+
+            self.logger.info(
+                "Database extract dataframe built",
+                extra_fields={
+                    "resource_name": resource_meta.resource_name,
+                    "source": resource_meta.source_name,
+                    "request_context_count": request_context_count,
+                    "extract_invocations": extract_invocations,
+                },
+            )
+
+            if configured_fields:
+                fields = configured_fields
+            else:
+                fields = [SchemaField(name=c, source=c) for c in df.columns]
+                self.logger.info(
+                    "Database extract has no configured fields; inferring output columns from extract",
+                    extra_fields={
+                        "resource_name": resource_meta.resource_name,
+                        "source": resource_meta.source_name,
+                        "inferred_columns": list(df.columns),
+                    },
                 )
-            return all_df
+            select_cols = []
+            for f in fields:
+                if f.source not in df.columns:
+                    raise HandlerError(
+                        f"Configured field source {f.source!r} not in extract columns: {list(df.columns)}",
+                        operation="process_resource",
+                        details={
+                            "resource_name": resource_meta.resource_name,
+                            "source": resource_meta.source_name,
+                        },
+                    )
+                select_cols.append(col(f.source).cast("string").alias(f.name))
+            return df.select(*select_cols)
         finally:
             service.close()
 

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -1824,7 +1824,7 @@ class DynamicHandler(BaseHandler):
                 select_query=resource_config.database_select_query,
                 spark_session=self.spark,
             )
-            extract_invocations = 1
+            extract_invocations += 1
 
             if configured_fields:
                 fields = configured_fields

--- a/tests/test_handler/test_dynamic_handler_database_fields.py
+++ b/tests/test_handler/test_dynamic_handler_database_fields.py
@@ -27,6 +27,7 @@ def spark_session() -> SparkSession:
 class _FakeDbService:
     def __init__(self, spark: SparkSession) -> None:
         self._spark = spark
+        self.extract_table_calls = 0
 
     def connect(self) -> None:
         return None
@@ -35,6 +36,7 @@ class _FakeDbService:
         return None
 
     def extract_table(self, schema, table, select_query=None, spark_session=None):
+        self.extract_table_calls += 1
         return self._spark.createDataFrame([(1, "x")], schema=["id", "label"])
 
 
@@ -85,3 +87,51 @@ def test_build_database_dataframe_respects_configured_fields(spark_session: Spar
     )
     assert out is not None
     assert out.columns == ["user_id"]
+
+
+def test_build_database_dataframe_single_extract_with_multiple_contexts(
+    spark_session: SparkSession,
+) -> None:
+    """Multiple request contexts must not re-run JDBC extract or duplicate rows (issue #11)."""
+    handler = object.__new__(DynamicHandler)
+    handler.spark = spark_session
+    handler.logger = get_logger("test_dynamic_handler_db")
+
+    rc = ResourceConfig(method="GET", database_schema="public", database_table="users")
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies=set(),
+        batch_inputs={},
+        config=rc,
+    )
+
+    fake = _FakeDbService(spark_session)
+    contexts = [{"batch": 1}, {"batch": 2}, {"batch": 3}]
+    out = DynamicHandler._build_database_dataframe(handler, fake, meta, request_contexts=contexts)
+
+    assert fake.extract_table_calls == 1
+    assert out is not None
+    assert out.count() == 1
+    assert set(out.columns) == {"id", "label"}
+
+
+def test_build_database_dataframe_no_contexts_no_extract(spark_session: SparkSession) -> None:
+    handler = object.__new__(DynamicHandler)
+    handler.spark = spark_session
+    handler.logger = get_logger("test_dynamic_handler_db")
+
+    rc = ResourceConfig(method="GET", database_schema="public", database_table="users")
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies=set(),
+        batch_inputs={},
+        config=rc,
+    )
+
+    fake = _FakeDbService(spark_session)
+    out = DynamicHandler._build_database_dataframe(handler, fake, meta, request_contexts=[])
+
+    assert fake.extract_table_calls == 0
+    assert out is None

--- a/tests/test_handler/test_dynamic_handler_database_fields.py
+++ b/tests/test_handler/test_dynamic_handler_database_fields.py
@@ -25,9 +25,11 @@ def spark_session() -> SparkSession:
 
 
 class _FakeDbService:
+    """Spy for DB services: ``extract_invocations`` matches handler log field of the same name."""
+
     def __init__(self, spark: SparkSession) -> None:
         self._spark = spark
-        self.extract_table_calls = 0
+        self.extract_invocations = 0
 
     def connect(self) -> None:
         return None
@@ -36,7 +38,7 @@ class _FakeDbService:
         return None
 
     def extract_table(self, schema, table, select_query=None, spark_session=None):
-        self.extract_table_calls += 1
+        self.extract_invocations += 1
         return self._spark.createDataFrame([(1, "x")], schema=["id", "label"])
 
 
@@ -110,7 +112,7 @@ def test_build_database_dataframe_single_extract_with_multiple_contexts(
     contexts = [{"batch": 1}, {"batch": 2}, {"batch": 3}]
     out = DynamicHandler._build_database_dataframe(handler, fake, meta, request_contexts=contexts)
 
-    assert fake.extract_table_calls == 1
+    assert fake.extract_invocations == 1
     assert out is not None
     assert out.count() == 1
     assert set(out.columns) == {"id", "label"}
@@ -133,5 +135,5 @@ def test_build_database_dataframe_no_contexts_no_extract(spark_session: SparkSes
     fake = _FakeDbService(spark_session)
     out = DynamicHandler._build_database_dataframe(handler, fake, meta, request_contexts=[])
 
-    assert fake.extract_table_calls == 0
+    assert fake.extract_invocations == 0
     assert out is None


### PR DESCRIPTION
## Summary

Database resources: run a single `extract_table` per resource run instead of once per `request_contexts` entry, so batch/backfill context expansion no longer repeats identical JDBC reads or duplicates rows. Log `request_context_count` and `extract_invocations`. Document behavior in the configuration overview.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

Fixes #11 .
