### PR TITLE
Feat/10 jdbc partitioned extract

### DIFF
--- a/config/examples/postgres.example.yml
+++ b/config/examples/postgres.example.yml
@@ -31,6 +31,18 @@ resources:
     database_table: users
     # Optional: read via custom SQL instead of a full-table scan (schema/table still used for metadata/logging).
     # database_select_query: "SELECT id, name FROM public.users WHERE active = true"
+    #
+    # Optional Spark JDBC read tuning (see docs/configuration/overview.md; honored for postgresql in this repo):
+    # table_read_options:
+    #   fetch_size: 5000
+    #   # Range partitioning — supply bounds explicitly; partition_column must suit Spark's partitioner:
+    #   # partition_column: id
+    #   # lower_bound: 1
+    #   # upper_bound: 1000000
+    #   # num_partitions: 8
+    #   # log_exact_row_count: false   # default: skip df.count() when parallel read is configured
+    #   # Or use predicates instead of partition_column (mutually exclusive):
+    #   # predicates: ["id < 500000", "id >= 500000"]
     fields:
       - name: id
         source: id

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -5,6 +5,7 @@
 - [Configuration Layout](#configuration-layout)
 - [Main Structure](#main-structure)
 - [Configuration Topics](#configuration-topics)
+- [Spark JDBC read tuning (database resources)](#spark-jdbc-read-tuning-database-resources)
 
 ## Configuration Layout
 
@@ -71,3 +72,16 @@ sources:
 | [Auth](auth.md) | OAuth JWT, bearer token, API key |
 | [Transformations](transformations.md) | add_column, add_column_from_request, ensure_param_values_in_output |
 | **PostgreSQL / HANA** | `type: postgresql` or `type: hana` with JDBC-style connection fields. PostgreSQL requires `database`. For HANA, `database` is the **tenant database name** passed to hdbcli as `databaseName` (must match a real tenant; errors such as `database '…' not connected` usually mean the wrong name). It can be omitted when your `host:port` already targets a single tenant. See [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml). |
+
+### Spark JDBC read tuning (database resources)
+
+Optional **`table_read_options`** describes **Spark `DataFrameReader.jdbc`** options: parallel range reads, predicate lists, JDBC `fetchSize`, and whether to run an exact `count()` after the read for logs. That matches sources whose service implementation reads through Spark JDBC (for example **PostgreSQL** in this repository).
+
+Other database source types may use a different read path (for example HANA today uses SQLAlchemy on the driver). For those, the same YAML block is **rejected at config validation until implemented** for that source type, so configuration stays portable without implying unsupported features are active.
+
+- **`fetch_size`**: optional JDBC `fetchSize` hint (positive integer) in Spark connection properties when the backend uses Spark JDBC.
+- **Range partitioning** (mutually exclusive with `predicates`): **`partition_column`**, **`lower_bound`**, **`upper_bound`**, **`num_partitions`**. Bounds are **operator-supplied** (Spine does not infer min/max). The column must suit Spark’s JDBC partitioner (typically an integer key).
+- **`predicates`**: non-empty list of `WHERE` fragments for predicate-based JDBC reads. Do not combine with range mode fields.
+- **`log_exact_row_count`**: when `true`, run `df.count()` after read for exact logging (extra scan). When `false` and a parallel read is configured, that count is skipped.
+
+Future JDBC-backed sources (for example MySQL or Redshift) can reuse this block once they use the same Spark read path. See commented examples in [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml).

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -747,6 +747,11 @@ class TableReadOptions(BaseModel):
                     "table_read_options.lower_bound and upper_bound are required when "
                     "partition_column is set"
                 )
+            if self.lower_bound > self.upper_bound:
+                raise ValueError(
+                    "table_read_options.lower_bound must be less than or equal to upper_bound "
+                    "(Spark JDBC range partitioning)"
+                )
         return self
 
 

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -674,6 +674,82 @@ class PythonSDKConfig(BaseModel):
     )
 
 
+class TableReadOptions(BaseModel):
+    """
+    Optional Spark ``DataFrameReader.jdbc`` read tuning for large relational table extracts.
+
+    Use either **range partitioning** (partition_column + bounds + num_partitions) or
+    **predicates** (list of WHERE fragments for parallel reads), not both.
+    Source types that do not read via Spark JDBC yet reject this block at validation time.
+    """
+
+    fetch_size: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="JDBC fetchSize hint passed through Spark connection properties.",
+    )
+    partition_column: Optional[str] = Field(
+        default=None,
+        description="Numeric (or date-castable) column for Spark parallel range reads.",
+    )
+    lower_bound: Optional[Union[int, float]] = Field(
+        default=None,
+        description="Inclusive lower bound for partition_column (operator-supplied).",
+    )
+    upper_bound: Optional[Union[int, float]] = Field(
+        default=None,
+        description="Inclusive upper bound for partition_column (operator-supplied).",
+    )
+    num_partitions: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Number of JDBC partitions when using partition_column.",
+    )
+    predicates: Optional[List[str]] = Field(
+        default=None,
+        description="Spark JDBC predicates (WHERE fragments); mutually exclusive with range mode.",
+    )
+    log_exact_row_count: bool = Field(
+        default=False,
+        description=(
+            "When True, run df.count() after read for exact row logging (full scan). "
+            "When False and a parallel read is configured, row count is omitted to avoid an extra scan."
+        ),
+    )
+
+    def uses_parallel_read(self) -> bool:
+        """True when Spark will use column range or predicate-based JDBC partitioning for this resource."""
+        if self.predicates is not None and len(self.predicates) > 0:
+            return True
+        col = (self.partition_column or "").strip()
+        return bool(col)
+
+    @model_validator(mode="after")
+    def validate_partitioning(self) -> "TableReadOptions":
+        if self.predicates is not None and len(self.predicates) == 0:
+            raise ValueError("table_read_options.predicates must be non-empty when set")
+
+        has_pred = self.predicates is not None and len(self.predicates) > 0
+        col = (self.partition_column or "").strip()
+        has_range = bool(col)
+
+        if has_pred and has_range:
+            raise ValueError(
+                "table_read_options: use either predicates or partition_column range mode, not both"
+            )
+        if has_range:
+            if self.num_partitions is None:
+                raise ValueError(
+                    "table_read_options.num_partitions is required when partition_column is set"
+                )
+            if self.lower_bound is None or self.upper_bound is None:
+                raise ValueError(
+                    "table_read_options.lower_bound and upper_bound are required when "
+                    "partition_column is set"
+                )
+        return self
+
+
 class ResourceConfig(BaseModel):
     """Configuration for a single ingest resource (REST, SDK, or future source types)."""
 
@@ -742,6 +818,14 @@ class ResourceConfig(BaseModel):
     database_select_query: Optional[str] = Field(
         default=None,
         description="Optional full SQL query for extract; when set, schema/table may still be used for logging.",
+    )
+    table_read_options: Optional[TableReadOptions] = Field(
+        default=None,
+        description=(
+            "Optional table read tuning (Spark JDBC partitioning, fetch size, logging). "
+            "Honored when the source service uses Spark read.jdbc; other database implementations "
+            "may reject this block until they support the same read path."
+        ),
     )
 
     def resolve_parameters(
@@ -983,6 +1067,11 @@ class SourceConfig(BaseModel):
             for resource_name, resource in self.resources.items():
                 if not resource.enabled:
                     continue
+                if resource.table_read_options is not None and self.type == SourceType.HANA:
+                    raise ValueError(
+                        f"{self.type.value} resource '{resource_name}' cannot use table_read_options "
+                        "until this source type reads via Spark JDBC (hana uses a different extract path today)"
+                    )
                 sch = (resource.database_schema or "").strip()
                 tbl = (resource.database_table or "").strip()
                 if not sch or not tbl:

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -1807,6 +1807,7 @@ class DynamicHandler(BaseHandler):
                     table=table,
                     select_query=resource_config.database_select_query,
                     spark_session=self.spark,
+                    table_read_options=resource_config.table_read_options,
                 )
                 if configured_fields:
                     fields = configured_fields

--- a/src/service/hana_service.py
+++ b/src/service/hana_service.py
@@ -8,7 +8,7 @@ from pyspark.sql import DataFrame, Row, SparkSession
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import SAWarning
 
-from src.config.config_models import SourceConfig, SourceType
+from src.config.config_models import SourceConfig, SourceType, TableReadOptions
 from src.config.settings import Settings
 from src.service.sql_database_service import SqlDatabaseService
 from src.utils.exceptions import ServiceError
@@ -84,7 +84,9 @@ class HanaService(SqlDatabaseService):
         schema: str,
         table: str,
         select_query: Optional[str],
+        table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
+        _ = table_read_options  # HANA reads via SQLAlchemy, not Spark read.jdbc; tuning not applied here yet.
         table_ref = self._table_label_for_log(schema, table)
         if select_query:
             query = select_query

--- a/src/service/postgres_service.py
+++ b/src/service/postgres_service.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pyspark.sql import DataFrame, SparkSession
 
-from src.config.config_models import SourceConfig, SourceType
+from src.config.config_models import SourceConfig, SourceType, TableReadOptions
 from src.config.settings import Settings
 from src.service.sql_database_service import SqlDatabaseService
 from src.utils.exceptions import ServiceError
@@ -64,6 +64,7 @@ class PostgresService(SqlDatabaseService):
         schema: str,
         table: str,
         select_query: Optional[str],
+        table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
         jdbc_url = self._build_jdbc_url()
         table_ref = self._table_label_for_log(schema, table)
@@ -81,8 +82,29 @@ class PostgresService(SqlDatabaseService):
         if self.config.connection_params:
             for k, v in self.config.connection_params.items():
                 connection_properties[str(k)] = str(v)
+        if table_read_options is not None and table_read_options.fetch_size is not None:
+            connection_properties["fetchsize"] = str(table_read_options.fetch_size)
 
-        return spark_session.read.jdbc(
+        reader = spark_session.read
+        if table_read_options is not None and table_read_options.predicates:
+            return reader.jdbc(
+                url=jdbc_url,
+                table=query,
+                predicates=table_read_options.predicates,
+                properties=connection_properties,
+            )
+        if table_read_options is not None and (table_read_options.partition_column or "").strip():
+            col = table_read_options.partition_column.strip()
+            return reader.jdbc(
+                url=jdbc_url,
+                table=query,
+                column=col,
+                lowerBound=table_read_options.lower_bound,
+                upperBound=table_read_options.upper_bound,
+                numPartitions=table_read_options.num_partitions,
+                properties=connection_properties,
+            )
+        return reader.jdbc(
             url=jdbc_url,
             table=query,
             properties=connection_properties,

--- a/src/service/sql_database_service.py
+++ b/src/service/sql_database_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 from pyspark.sql import DataFrame, SparkSession
 
-from src.config.config_models import SourceConfig
+from src.config.config_models import SourceConfig, TableReadOptions
 from src.config.settings import Settings
 from src.service.base_service import BaseSourceService
 from src.utils.exceptions import ServiceError
@@ -118,6 +118,7 @@ class SqlDatabaseService(BaseSourceService, ABC):
         schema: str,
         table: str,
         select_query: Optional[str],
+        table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
         """Backend-specific read into a Spark DataFrame."""
 
@@ -127,6 +128,7 @@ class SqlDatabaseService(BaseSourceService, ABC):
         table: str,
         select_query: Optional[str] = None,
         spark_session: Optional[Any] = None,
+        table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
         spark_session = self._require_spark(spark_session, operation="extract_table")
         self._ensure_extract_prerequisites()
@@ -147,13 +149,40 @@ class SqlDatabaseService(BaseSourceService, ABC):
                     extra_fields=fields,
                 )
 
-            df = self._load_dataframe(spark_session, schema, table, select_query)
-
-            row_count = df.count()
-            logger.info(
-                f"Successfully extracted {row_count} rows from '{table_label}'",
-                extra_fields={**fields, "row_count": row_count},
+            df = self._load_dataframe(
+                spark_session,
+                schema,
+                table,
+                select_query,
+                table_read_options=table_read_options,
             )
+
+            extra_log: Dict[str, Any] = {**fields}
+            if table_read_options is not None:
+                if table_read_options.fetch_size is not None:
+                    extra_log["fetch_size"] = table_read_options.fetch_size
+                if table_read_options.predicates:
+                    extra_log["predicates_count"] = len(table_read_options.predicates)
+                if (table_read_options.partition_column or "").strip():
+                    extra_log["partition_column"] = table_read_options.partition_column.strip()
+                    extra_log["num_partitions"] = table_read_options.num_partitions
+
+            should_count = True
+            if table_read_options is not None and table_read_options.uses_parallel_read():
+                should_count = table_read_options.log_exact_row_count
+
+            if should_count:
+                row_count = df.count()
+                logger.info(
+                    f"Successfully extracted {row_count} rows from '{table_label}'",
+                    extra_fields={**extra_log, "row_count": row_count},
+                )
+            else:
+                logger.info(
+                    f"Successfully extracted from '{table_label}' (parallel JDBC read; "
+                    f"exact row count skipped; set table_read_options.log_exact_row_count to count)",
+                    extra_fields=extra_log,
+                )
             return df
 
         except ServiceError:

--- a/tests/test_config/test_table_read_options_config.py
+++ b/tests/test_config/test_table_read_options_config.py
@@ -1,0 +1,97 @@
+"""Tests for ``TableReadOptions`` and source validation (issue #10)."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.config_models import (
+    ResourceConfig,
+    SourceConfig,
+    SourceType,
+    TableReadOptions,
+)
+
+
+def test_table_read_options_range_valid() -> None:
+    c = TableReadOptions(
+        partition_column="id",
+        lower_bound=1,
+        upper_bound=1000,
+        num_partitions=4,
+    )
+    assert c.uses_parallel_read()
+
+
+def test_table_read_options_predicates_valid() -> None:
+    c = TableReadOptions(predicates=["id < 500", "id >= 500"])
+    assert c.uses_parallel_read()
+
+
+def test_table_read_options_mutually_exclusive() -> None:
+    with pytest.raises(ValidationError):
+        TableReadOptions(
+            partition_column="id",
+            lower_bound=1,
+            upper_bound=10,
+            num_partitions=2,
+            predicates=["x = 1"],
+        )
+
+
+def test_table_read_options_range_missing_bounds() -> None:
+    with pytest.raises(ValidationError):
+        TableReadOptions(partition_column="id", num_partitions=4)
+
+
+def test_table_read_options_empty_predicates() -> None:
+    with pytest.raises(ValidationError):
+        TableReadOptions(predicates=[])
+
+
+def test_table_read_options_fetch_only() -> None:
+    c = TableReadOptions(fetch_size=1000)
+    assert not c.uses_parallel_read()
+
+
+def test_postgres_allows_table_read_options() -> None:
+    SourceConfig(
+        type=SourceType.POSTGRESQL,
+        host="localhost",
+        port=5432,
+        username="u",
+        password="p",
+        database="db",
+        resources={
+            "t": ResourceConfig(
+                method="GET",
+                database_schema="public",
+                database_table="t",
+                table_read_options=TableReadOptions(
+                    partition_column="id",
+                    lower_bound=0,
+                    upper_bound=99,
+                    num_partitions=2,
+                ),
+            )
+        },
+    )
+
+
+def test_hana_rejects_table_read_options() -> None:
+    with pytest.raises(ValidationError) as exc:
+        SourceConfig(
+            type=SourceType.HANA,
+            host="localhost",
+            port=30015,
+            username="u",
+            password="p",
+            resources={
+                "t": ResourceConfig(
+                    method="GET",
+                    database_schema="S",
+                    database_table="T",
+                    table_read_options=TableReadOptions(fetch_size=500),
+                )
+            },
+        )
+    msg = str(exc.value).lower()
+    assert "table_read_options" in msg or "spark" in msg or "hana" in msg

--- a/tests/test_config/test_table_read_options_config.py
+++ b/tests/test_config/test_table_read_options_config.py
@@ -42,6 +42,17 @@ def test_table_read_options_range_missing_bounds() -> None:
         TableReadOptions(partition_column="id", num_partitions=4)
 
 
+def test_table_read_options_range_rejects_inverted_bounds() -> None:
+    with pytest.raises(ValidationError) as exc:
+        TableReadOptions(
+            partition_column="id",
+            lower_bound=100,
+            upper_bound=1,
+            num_partitions=4,
+        )
+    assert "lower_bound" in str(exc.value).lower() and "upper_bound" in str(exc.value).lower()
+
+
 def test_table_read_options_empty_predicates() -> None:
     with pytest.raises(ValidationError):
         TableReadOptions(predicates=[])

--- a/tests/test_handler/test_dynamic_handler_database_fields.py
+++ b/tests/test_handler/test_dynamic_handler_database_fields.py
@@ -34,7 +34,9 @@ class _FakeDbService:
     def close(self) -> None:
         return None
 
-    def extract_table(self, schema, table, select_query=None, spark_session=None):
+    def extract_table(
+        self, schema, table, select_query=None, spark_session=None, table_read_options=None
+    ):
         return self._spark.createDataFrame([(1, "x")], schema=["id", "label"])
 
 


### PR DESCRIPTION
## Summary

Add optional `table_read_options` for PostgreSQL (Spark JDBC range or predicate partitioning, `fetch_size`, optional exact row count), validate and reject on HANA for now (extended scope in #23  ) , gate `df.count()` for parallel reads, wire from `DynamicHandler`, docs + example.  

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

Fixes #10 .
