### PR TITLE
Feature/issue 22 reject db multi request contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 - `src/config/`: config loading, validation, settings, and schema models
 - `src/handler/`: pipeline orchestration and resource execution flow
 - `src/planner/`: execution planning, dependency resolution, and staged runs
-- `src/service/`: source integrations such as REST, PostgreSQL, HANA, and Python SDK services
+- `src/service/`: source integrations such as REST, relational database connectors, and Python SDK services
 - `src/parser/`: lightweight transformations over collected data
 - `src/collector/`: collection/storage strategy during extraction
 - `src/loader/`: destination loading such as S3
@@ -17,10 +17,12 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 
 ## Working Rules
 
+- **Refresh this file when patterns change** — Whenever you establish or clarify a convention that should hold across the repo (where validation lives, how errors are phrased, how new source types register, duplication policy above), update `AGENTS.md` in the same change set so later contributors and assistants inherit it without repeated reminders.
+- **Single source of truth** — If two symbols express the same rule (for example a module-level predicate and a class staticmethod that only forwards to it), consolidate to one public entry point and update call sites. Do not preserve duplicate APIs for habit or “convenience.”
 - Prefer extending existing abstractions over adding source-specific branching in the main flow.
 - Keep concerns separated: auth, extraction, parsing, collection, loading, and planning should stay modular.
 - Preserve config-first behavior. New sources, resources, and tables should primarily be enabled through YAML under `config/`.
-- Fail early. If you change config shape or runtime assumptions, update validation in `src/config/` instead of relying on runtime errors.
+- Fail early. If you change config shape or runtime assumptions, update validation in `src/config/` (and the planner when the check depends on the execution graph) instead of relying on runtime errors.
 - Be explicit about production concerns: retries, logging, failure isolation, and backfill behavior should remain visible in code and docs.
 - Be critical of requested changes. Do not just implement the first workable idea if it adds avoidable coupling, weakens production behavior, or bloats the codebase.
 - Help operators get to the best solution, not just the fastest patch. Challenge assumptions when a request conflicts with maintainability, observability, or engineering best practices.
@@ -35,7 +37,7 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 
 - New auth behavior: extend the service/auth configuration model and validation together.
 - New destination: add a loader under `src/loader/`, register it in `src/loader/loader_factory.py`, and document any new config.
-- New source/service type: implement it under `src/service/`, wire it through the factory/config models, and avoid bypassing planner/handler flow.
+- New source/service type: implement it under `src/service/`, wire it through the factory/config models, and avoid bypassing planner/handler flow. For a new **relational database** kind that shares the same table/query extract and request-context rules, add its `SourceType` to `is_database_source_type()` in `src/config/config_models.py` (that function is the only database-kind predicate; call it from planner, handler, and validators rather than re-listing types).
 - New transformation or collection behavior should fit the existing parser/collector split rather than being embedded ad hoc in services.
 
 ## Quality Bar
@@ -45,6 +47,7 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 - Avoid hidden coupling across modules. If a change affects planning, config, and runtime behavior, update all three deliberately.
 - Be skeptical of convenience shortcuts that weaken validation, observability, or repeatability.
 - Prefer the smallest change that keeps the design clean. Avoid introducing new abstractions, flags, or special cases unless they clearly earn their keep.
+- **No issue or PR references in implementation code** — Do not put GitHub issue numbers, pull request numbers, or links in source comments, docstrings, or user-facing error messages. Traceability belongs in commit messages and PR descriptions (see **GitHub issues** below). Describe behavior objectively so docs and errors stay accurate as new source types are added (avoid hardcoding today's short list of database or API names unless the text is truly specific to one integration).
 
 ## Docs Expectations
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -5,11 +5,8 @@
 - [Configuration Layout](#configuration-layout)
 - [Main Structure](#main-structure)
 - [Configuration Topics](#configuration-topics)
-<<<<<<< HEAD
 - [Spark JDBC read tuning (database resources)](#spark-jdbc-read-tuning-database-resources)
-=======
 - [Database resources and request contexts](#database-resources-and-request-contexts)
->>>>>>> origin/dev
 
 ## Configuration Layout
 
@@ -92,8 +89,9 @@ Future JDBC-backed sources (for example MySQL or Redshift) can reuse this block 
 
 ### Database resources and request contexts
 
-For PostgreSQL and HANA resources, Spine reads the configured table (or `database_select_query`) **once per resource run**, regardless of how many [request contexts](parameters.md) batching or backfill produces. Request contexts still drive REST/SDK calls; they do **not** cause repeated `SELECT`-style extracts of the same static query.
+For **database-backed** resources (relational sources configured with `database_schema` / `database_table` or `database_select_query`), Spine reads the configured table or query **once per resource run**. [Request contexts](parameters.md) from `batch_inputs` and related expansion drive REST/SDK calls on other source types; on database resources they do not cause repeated `SELECT`-style extracts of the same static query.
 
-- **Why:** The handler does not substitute per-context values into `database_schema`, `database_table`, or `database_select_query` today. Running one extract avoids duplicate database load and avoids duplicating identical rows in Spark when `request_contexts` has length greater than one.
-- **Transformations:** When transformations run on database-sourced DataFrames, the request context passed in is taken from **`request_contexts[0]`** (first context after expansion). Design batch inputs and transforms accordingly.
+- **Rejection:** If expansion would produce **more than one** request context for a database-backed resource, Spine **fails before ingest** when that is provable from static batch configuration (execution plan build). If batch values are resolved only at run time (for example from other resources), the handler **still raises** after expansion (after any `record_limit` on contexts) and before the extract. Only the first context would influence transformations otherwise. Fix the pipeline by removing batch expansion for that resource, using a single context (for example via `record_limit`), or splitting work into separate resources.
+- **Why:** The handler does not substitute per-context values into `database_schema`, `database_table`, or `database_select_query` today. A single extract avoids duplicate database load and avoids duplicating identical rows in Spark.
+- **Transformations:** When transformations run on database-sourced DataFrames, the request context passed in is taken from **`request_contexts[0]`** (the sole context after a successful run). Design transforms for that single context.
 - **Scoping data:** To limit which rows are read, set **`database_select_query`** to the SQL you need (static query in YAML). Per-context or templated SQL is not supported yet; if you need different extracts per context, split into separate resources or follow future docs for SQL templating.

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -221,7 +221,7 @@ class ConfigLoader:
             "auth",
             "headers",
             "resources",
-            # Relational database sources (postgresql / hana)
+            # Relational database-backed sources (see is_database_source_type)
             "host",
             "port",
             "username",

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -22,11 +22,9 @@ from pydantic import (
 from src.utils.dynamic_values import (
     ComplexDynamicValue,
     DynamicOrStaticValue,
+    DynamicSourceReference,
     DynamicValueType,
     get_resolver,
-)
-from src.utils.dynamic_values import (
-    SourceConfig as DynamicValueSourceConfig,
 )
 from src.utils.redis_context import RedisContextManager
 
@@ -479,12 +477,13 @@ class InputConfig(BaseModel):
             self.value.type == DynamicValueType.SOURCE and self.value.source_config is not None
         )
 
-    def get_source_config(self) -> Optional[DynamicValueSourceConfig]:
+    def get_source_config(self) -> Optional[DynamicSourceReference]:
         """
         Get the source configuration if this parameter has one defined.
 
         Returns:
-            Optional[DynamicValueSourceConfig]: Source configuration if value is a ComplexDynamicValue with SOURCE
+            Optional[DynamicSourceReference]: Reference to another source's field when value is a
+            ComplexDynamicValue with SOURCE type and ``source_config`` is set.
         """
         if isinstance(self.value, ComplexDynamicValue) and (
             self.value.type == DynamicValueType.SOURCE and self.value.source_config is not None

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -811,7 +811,7 @@ class ResourceConfig(BaseModel):
         description="Configuration to ensure all parameter values are present in the output dataframe",
     )
 
-    # Relational database extract target (used when source type is postgresql or hana)
+    # Relational database extract target (used when source type is a database kind)
     database_schema: Optional[str] = Field(
         default=None,
         description="Database schema for JDBC/HANA extract (required for database source types on this resource).",
@@ -1016,6 +1016,17 @@ class SourceType(StrEnum):
     HANA = "hana"
 
 
+def is_database_source_type(source_type: SourceType) -> bool:
+    """
+    Return True for source kinds that use the relational database extract path
+    (single table or query read per resource run, shared request-context rules).
+
+    Add new database ``SourceType`` values here when wiring a backend through the
+    same planner and handler behavior.
+    """
+    return source_type in (SourceType.POSTGRESQL, SourceType.HANA)
+
+
 class SourceConfig(BaseModel):
     """Data source configuration."""
 
@@ -1029,7 +1040,7 @@ class SourceConfig(BaseModel):
     )
     resources: Dict[str, ResourceConfig]
 
-    # Relational database connection (postgresql / hana)
+    # Relational database connection (see ``is_database_source_type`` for supported kinds)
     host: Optional[str] = Field(default=None, description="Database host")
     port: Optional[Union[int, str]] = Field(default=None, description="Database port")
     username: Optional[str] = Field(default=None, description="Database user")
@@ -1047,10 +1058,6 @@ class SourceConfig(BaseModel):
         description="Extra JDBC properties or URL query parameters (driver-specific).",
     )
 
-    @staticmethod
-    def _is_database_source(t: SourceType) -> bool:
-        return t in (SourceType.POSTGRESQL, SourceType.HANA)
-
     @model_validator(mode="after")
     def validate_source_type(self):
         """Validate that source type matches required fields."""
@@ -1060,7 +1067,7 @@ class SourceConfig(BaseModel):
         elif self.type == SourceType.PYTHON_SDK:
             if not self.sdk:
                 raise ValueError("sdk configuration is required for python_sdk source type")
-        elif self._is_database_source(self.type):
+        elif is_database_source_type(self.type):
             if not self.host:
                 raise ValueError(f"{self.type.value} source requires host")
             if self.port is None or str(self.port).strip() == "":

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -25,12 +25,15 @@ from src.config.config_models import (
     ResourceConfig,
     SchemaField,
     SourceConfig,
-    SourceType,
+    is_database_source_type,
 )
 from src.config.settings import Settings
 from src.handler.base_handler import BaseHandler, HandlerError
 from src.loader.loader_factory import LoaderFactory
 from src.parser.spark_parser import SparkParser
+from src.planner.database_request_context import (
+    reject_if_database_has_multiple_runtime_request_contexts,
+)
 from src.planner.execution_plan import ExecutionPlan, ResourceMetadata
 from src.service.service_factory import ServiceFactory
 from src.utils.backfill_dates import generate_backfill_date_pairs
@@ -855,7 +858,7 @@ class DynamicHandler(BaseHandler):
                         f"Probing source connectivity for {source_name} using resource: {resource_name}"
                     )
 
-                    if source_config.type in (SourceType.POSTGRESQL, SourceType.HANA):
+                    if is_database_source_type(source_config.type):
                         try:
                             service.connect()
                             self.logger.debug(
@@ -1778,9 +1781,6 @@ class DynamicHandler(BaseHandler):
                 )
             )
 
-    def _is_database_source(self, source_config: SourceConfig) -> bool:
-        return source_config.type in (SourceType.POSTGRESQL, SourceType.HANA)
-
     def _build_database_dataframe(
         self,
         service: Any,
@@ -1788,14 +1788,14 @@ class DynamicHandler(BaseHandler):
         request_contexts: List[Dict[str, Any]],
     ) -> Optional[DataFrame]:
         """
-        Connect, extract via Spark JDBC / HANA driver, project to configured fields (string typed).
+        Connect, extract via the database source service, project to configured fields (string typed).
 
         When ``fields`` is omitted or empty, output columns match the extract (name and source
         equal each result column), same idea as REST resources without an explicit field list.
 
         The physical table (or ``database_select_query``) is resolved once per resource run:
         ``extract_table`` is not repeated per ``request_contexts`` entry. Batch-expanded contexts
-        affect REST/SDK requests, not multiple JDBC reads of the same query. Transformations
+        affect REST/SDK requests, not multiple reads of the same query. Transformations
         for database resources still receive ``request_contexts[0]`` as request context.
         """
         resource_config = resource_meta.config
@@ -1901,7 +1901,7 @@ class DynamicHandler(BaseHandler):
             if self.spark is None:
                 raise HandlerError("Spark session is not initialized for processing")
 
-            is_db = self._is_database_source(source_config)
+            is_db = is_database_source_type(source_config.type)
 
             # Check if streaming is enabled for this resource
             streaming_config = resource_config.get_streaming_config(self.config.defaults.streaming)
@@ -2041,6 +2041,16 @@ class DynamicHandler(BaseHandler):
                 use_backfill=use_backfill,
             )
             total_contexts = len(request_contexts)
+            # Static multi-context database batching fails at plan build; this only catches
+            # runtime-resolved expansion (SOURCE inputs, Redis, etc.).
+            reject_if_database_has_multiple_runtime_request_contexts(
+                is_db=is_db,
+                request_context_count=total_contexts,
+                resource_name=resource_name,
+                source_name=source_name,
+                batch_input_keys=list(resource_meta.batch_inputs.keys()),
+                use_backfill=use_backfill,
+            )
             failed_context_count = 0
 
             # Process each context (HTTP/SDK only; database sources use Spark extract_table)

--- a/src/planner/database_request_context.py
+++ b/src/planner/database_request_context.py
@@ -22,8 +22,7 @@ class _SupportsStaticRequestCountEstimate(Protocol):
     resource_name: str
     batch_inputs: dict
 
-    def estimate_request_count(self) -> Optional[int]:
-        ...
+    def estimate_request_count(self) -> Optional[int]: ...
 
 
 def validate_plan_time_static_database_request_context_expansion(

--- a/src/planner/database_request_context.py
+++ b/src/planner/database_request_context.py
@@ -1,0 +1,88 @@
+"""
+Database-backed sources: request-context expansion vs a single extract per run.
+
+Plan-time checks use ``ResourceMetadata.estimate_request_count()`` so invalid
+static batch configuration fails when the execution plan is built. The handler
+still calls ``reject_if_database_has_multiple_runtime_request_contexts`` after
+resolving dynamic batch values (SOURCE inputs, Redis, etc.) that the planner
+cannot count.
+"""
+
+from typing import List, Optional, Protocol, runtime_checkable
+
+from src.config.config_models import SourceType, is_database_source_type
+from src.utils.exceptions import HandlerError, PlanningError
+
+
+@runtime_checkable
+class _SupportsStaticRequestCountEstimate(Protocol):
+    """Minimal shape for plan-time validation without importing circular types."""
+
+    source_name: str
+    resource_name: str
+    batch_inputs: dict
+
+    def estimate_request_count(self) -> Optional[int]:
+        ...
+
+
+def validate_plan_time_static_database_request_context_expansion(
+    meta: _SupportsStaticRequestCountEstimate,
+    *,
+    source_type: SourceType,
+) -> None:
+    """
+    Fail plan build when a database resource's batch inputs are purely static
+    and provably expand to more than one request context.
+    """
+    if not is_database_source_type(source_type):
+        return
+    est = meta.estimate_request_count()
+    if est is None or est <= 1:
+        return
+    raise PlanningError(
+        message=(
+            "A database-backed resource cannot expand to multiple request contexts from static "
+            "batch configuration: the extract runs once and transformations only use the first "
+            "context. Remove or narrow batch_inputs, split into separate resources, or use "
+            "dynamic inputs only if a single resolved context is intended."
+        ),
+        operation="validate_database_request_contexts",
+        details={
+            "source": meta.source_name,
+            "resource_name": meta.resource_name,
+            "estimated_request_context_count": est,
+            "batch_input_keys": list(meta.batch_inputs.keys()),
+        },
+    )
+
+
+def reject_if_database_has_multiple_runtime_request_contexts(
+    *,
+    is_db: bool,
+    request_context_count: int,
+    resource_name: str,
+    source_name: str,
+    batch_input_keys: List[str],
+    use_backfill: bool,
+) -> None:
+    """
+    Last line of defense after dynamic resolution: database extract is not repeated
+    per context and transformations only see the first context.
+    """
+    if not is_db or request_context_count <= 1:
+        return
+    raise HandlerError(
+        "Database resources cannot expand to multiple request contexts: "
+        "the table or select query is read once and transformations use only the first context. "
+        "Remove batching expansion for this resource, split it into separate resources, "
+        "or lower your request limit so a single context remains.",
+        operation="process_resource",
+        details={
+            "resource_name": resource_name,
+            "source": source_name,
+            "request_context_count": request_context_count,
+            "batch_input_keys": batch_input_keys,
+            "use_backfill": use_backfill,
+        },
+    )

--- a/src/planner/execution_plan.py
+++ b/src/planner/execution_plan.py
@@ -25,6 +25,9 @@ from src.config.config_models import (
     ResourceConfig,
     SourceConfig,
 )
+from src.planner.database_request_context import (
+    validate_plan_time_static_database_request_context_expansion,
+)
 from src.utils.databricks_utils import DatabricksUtils
 from src.utils.dynamic_values import ComplexDynamicValue, DynamicValueType, FilterConfig
 from src.utils.exceptions import PlanningError
@@ -300,6 +303,18 @@ class ExecutionPlan:
                             },
                         },
                     )
+
+        self._validate_database_resources_plan_time_request_contexts()
+
+    def _validate_database_resources_plan_time_request_contexts(self) -> None:
+        """Reject database resources whose static batch inputs expand to multiple contexts."""
+        for meta in self._resource_metadata.values():
+            source_config = self.get_source_config(meta.source_name)
+            if source_config is None:
+                continue
+            validate_plan_time_static_database_request_context_expansion(
+                meta, source_type=source_config.type
+            )
 
     def _load_dependency_queries(self) -> None:
         """

--- a/src/utils/dynamic_values.py
+++ b/src/utils/dynamic_values.py
@@ -141,8 +141,8 @@ class FilterConfig(BaseModel):
         return None
 
 
-class SourceConfig(BaseModel):
-    """Configuration for resolving values from other sources (resources)."""
+class DynamicSourceReference(BaseModel):
+    """Points at another source's field when ``DynamicValueType`` is ``SOURCE``."""
 
     source: str  # Source endpoint for dynamic values
     field: str  # Field to extract from source
@@ -167,7 +167,7 @@ class ComplexDynamicValue(BaseModel):
     databricks_config: Optional[DatabricksDeltaTableConfig] = (
         None  # Added for databricks delta table operations
     )
-    source_config: Optional[SourceConfig] = (
+    source_config: Optional[DynamicSourceReference] = (
         None  # Added for resolving values from other sources (resources)
     )
     pagination_config: Optional[Dict[str, Any]] = (

--- a/tests/test_config/test_table_read_options_config.py
+++ b/tests/test_config/test_table_read_options_config.py
@@ -1,4 +1,4 @@
-"""Tests for ``TableReadOptions`` and source validation (issue #10)."""
+"""Tests for ``TableReadOptions`` and related source validation."""
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_database_sources.py
+++ b/tests/test_database_sources.py
@@ -1,4 +1,4 @@
-"""Tests for database source types (PostgreSQL, HANA) configuration models."""
+"""Tests for relational database source configuration models."""
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_handler/test_dynamic_handler_database_fields.py
+++ b/tests/test_handler/test_dynamic_handler_database_fields.py
@@ -96,7 +96,7 @@ def test_build_database_dataframe_respects_configured_fields(spark_session: Spar
 def test_build_database_dataframe_single_extract_with_multiple_contexts(
     spark_session: SparkSession,
 ) -> None:
-    """Multiple request contexts must not re-run JDBC extract or duplicate rows (issue #11)."""
+    """Multiple request contexts must not re-run JDBC extract or duplicate rows."""
     handler = object.__new__(DynamicHandler)
     handler.spark = spark_session
     handler.logger = get_logger("test_dynamic_handler_db")

--- a/tests/test_handler/test_dynamic_handler_database_request_contexts.py
+++ b/tests/test_handler/test_dynamic_handler_database_request_contexts.py
@@ -1,0 +1,59 @@
+"""Runtime guards when database resources expand to multiple request contexts."""
+
+import pytest
+
+from src.handler.base_handler import HandlerError
+from src.planner.database_request_context import (
+    reject_if_database_has_multiple_runtime_request_contexts,
+)
+
+
+def test_reject_multiple_contexts_for_database_raises() -> None:
+    with pytest.raises(HandlerError) as exc_info:
+        reject_if_database_has_multiple_runtime_request_contexts(
+            is_db=True,
+            request_context_count=2,
+            resource_name="users",
+            source_name="pg",
+            batch_input_keys=["ids"],
+            use_backfill=False,
+        )
+    err = exc_info.value
+    assert err.operation == "process_resource"
+    assert err.details["request_context_count"] == 2
+    assert err.details["batch_input_keys"] == ["ids"]
+    assert err.details["use_backfill"] is False
+    assert "Database resources cannot expand" in str(err)
+
+
+def test_reject_multiple_contexts_skipped_when_not_database() -> None:
+    reject_if_database_has_multiple_runtime_request_contexts(
+        is_db=False,
+        request_context_count=5,
+        resource_name="api",
+        source_name="rest",
+        batch_input_keys=["x"],
+        use_backfill=True,
+    )
+
+
+def test_reject_multiple_contexts_skipped_when_single_context() -> None:
+    reject_if_database_has_multiple_runtime_request_contexts(
+        is_db=True,
+        request_context_count=1,
+        resource_name="users",
+        source_name="pg",
+        batch_input_keys=[],
+        use_backfill=False,
+    )
+
+
+def test_reject_multiple_contexts_skipped_when_zero_contexts() -> None:
+    reject_if_database_has_multiple_runtime_request_contexts(
+        is_db=True,
+        request_context_count=0,
+        resource_name="users",
+        source_name="pg",
+        batch_input_keys=[],
+        use_backfill=False,
+    )

--- a/tests/test_planner/test_database_request_context.py
+++ b/tests/test_planner/test_database_request_context.py
@@ -9,10 +9,8 @@ from src.planner.database_request_context import (
 from src.planner.execution_plan import ResourceMetadata
 from src.utils.dynamic_values import (
     ComplexDynamicValue,
+    DynamicSourceReference,
     DynamicValueType,
-)
-from src.utils.dynamic_values import (
-    SourceConfig as DynamicSourceConfig,
 )
 from src.utils.exceptions import PlanningError
 
@@ -105,7 +103,7 @@ def test_plan_time_skips_when_estimate_unknown_dynamic_batch() -> None:
             "parent_id": {
                 "value": ComplexDynamicValue(
                     type=DynamicValueType.SOURCE,
-                    source_config=DynamicSourceConfig(source="other", field="id"),
+                    source_config=DynamicSourceReference(source="other", field="id"),
                 ),
                 "location": "query",
                 "batch_size": 1,

--- a/tests/test_planner/test_database_request_context.py
+++ b/tests/test_planner/test_database_request_context.py
@@ -1,0 +1,124 @@
+"""Plan-time validation for database-backed resources and request-context expansion."""
+
+import pytest
+
+from src.config.config_models import ResourceConfig, SourceType
+from src.planner.database_request_context import (
+    validate_plan_time_static_database_request_context_expansion,
+)
+from src.planner.execution_plan import ResourceMetadata
+from src.utils.dynamic_values import (
+    ComplexDynamicValue,
+    DynamicValueType,
+)
+from src.utils.dynamic_values import (
+    SourceConfig as DynamicSourceConfig,
+)
+from src.utils.exceptions import PlanningError
+
+
+def test_plan_time_rejects_static_multi_context_database_resource() -> None:
+    rc = ResourceConfig(
+        method="GET",
+        database_schema="public",
+        database_table="users",
+        request_inputs={
+            "ids": {
+                "value": [1, 2, 3],
+                "location": "query",
+                "batch_size": 1,
+            }
+        },
+    )
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies=set(),
+        batch_inputs={"ids": 1},
+        config=rc,
+    )
+    with pytest.raises(PlanningError) as exc_info:
+        validate_plan_time_static_database_request_context_expansion(
+            meta, source_type=SourceType.POSTGRESQL
+        )
+    assert "database-backed resource cannot expand" in exc_info.value.message
+    assert exc_info.value.details["estimated_request_context_count"] == 3
+
+
+def test_plan_time_allows_single_context_database_with_static_batch() -> None:
+    rc = ResourceConfig(
+        method="GET",
+        database_schema="public",
+        database_table="users",
+        request_inputs={
+            "ids": {
+                "value": [42],
+                "location": "query",
+                "batch_size": 1,
+            }
+        },
+    )
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies=set(),
+        batch_inputs={"ids": 1},
+        config=rc,
+    )
+    validate_plan_time_static_database_request_context_expansion(
+        meta, source_type=SourceType.POSTGRESQL
+    )
+
+
+def test_plan_time_skips_non_database_source() -> None:
+    rc = ResourceConfig(
+        method="GET",
+        path="/x",
+        request_inputs={
+            "ids": {
+                "value": [1, 2],
+                "location": "query",
+                "batch_size": 1,
+            }
+        },
+    )
+    meta = ResourceMetadata(
+        source_name="api",
+        resource_name="r",
+        dependencies=set(),
+        batch_inputs={"ids": 1},
+        config=rc,
+    )
+    validate_plan_time_static_database_request_context_expansion(
+        meta, source_type=SourceType.REST_API
+    )
+
+
+def test_plan_time_skips_when_estimate_unknown_dynamic_batch() -> None:
+    """Dependencies make estimate_request_count None — planner cannot prove context count."""
+
+    rc = ResourceConfig(
+        method="GET",
+        database_schema="public",
+        database_table="users",
+        request_inputs={
+            "parent_id": {
+                "value": ComplexDynamicValue(
+                    type=DynamicValueType.SOURCE,
+                    source_config=DynamicSourceConfig(source="other", field="id"),
+                ),
+                "location": "query",
+                "batch_size": 1,
+            }
+        },
+    )
+    meta = ResourceMetadata(
+        source_name="pg",
+        resource_name="users",
+        dependencies={"pg.other"},
+        batch_inputs={"parent_id": 1},
+        config=rc,
+    )
+    validate_plan_time_static_database_request_context_expansion(
+        meta, source_type=SourceType.POSTGRESQL
+    )


### PR DESCRIPTION
## Summary

This change tightens how **database-backed** resources interact with **request context expansion**, centralizes how we detect those sources, keeps implementation text free of issue/Git references, and documents operator-visible behavior.

### Behavior
- **Plan build:** If static batching implies **more than one** request context for a database source, planning raises **`PlanningError`** (uses `ResourceMetadata.estimate_request_count()`).
- **Runtime:** After dynamic resolution (and `record_limit`), if a database source still has **more than one** context, the handler raises **`HandlerError`** before extract—covers cases the planner cannot prove statically.
- **`is_database_source_type()`** in `config_models` is the **single** predicate for database kinds; **`SourceConfig._is_database_source`** and **`DynamicHandler._is_database_source`** were removed in favor of calling it directly.

### Docs and conventions
- **`docs/configuration/overview.md`:** Describes rejection for database-backed resources and plan vs runtime failure.
- **`AGENTS.md`:** No issue/PR references in implementation code; refresh **AGENTS** when cross-cutting conventions change; avoid duplicate “wrapper” APIs; extend **`is_database_source_type()`** when adding DB backends that share the same extract/context rules.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

Fixes #22 .
