### PR TITLE
Feature/issue 14 object storage backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ logs/
 .DS_Store
 Thumbs.db
 
+# Local Spark loading output (see docs/configuration/loading.md)
+.spine/local-output/
+
 # Temp
 .temp/
 .write_test/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 - `src/service/`: source integrations such as REST, PostgreSQL, HANA, and Python SDK services
 - `src/parser/`: lightweight transformations over collected data
 - `src/collector/`: collection/storage strategy during extraction
-- `src/loader/`: destination loading such as S3
+- `src/loader/`: destination loading (S3, local, …), Spark writes, and `object_store` / `local_storage` helpers
 - `config/`: operator-local YAML and SQL; committed files here are templates and examples
 
 ## Working Rules
@@ -50,6 +50,7 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 
 - Keep the `README.md` practical and honest. Personality is fine, but claims should match the implementation.
 - Use `docs/getting-started.md`, `docs/deployment.md`, and `docs/configuration/` as the source of truth for setup and behavior details.
+- Write for someone discovering the project for the first time. Prefer direct, timeless descriptions of behavior and configuration. Avoid framing docs around past releases or repo history (for example “unchanged from earlier versions”, “previously”, “now you can”) unless you are explicitly documenting a breaking migration or upgrade path.
 
 ## GitHub issues
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ src/
 ├── handler/         # Pipeline orchestration
 ├── planner/         # Execution planning & dependency resolution
 ├── service/         # API/auth implementations
-├── loader/          # Data destinations (S3, etc.)
+├── loader/          # Data destinations (local filesystem, S3, …)
 ├── parser/          # Lightweight transformations
 ├── config/          # Config parsing and models
 ├── utils/

--- a/config/README.md
+++ b/config/README.md
@@ -24,4 +24,4 @@ The environment variable `CONFIG_PATH` selects a subdirectory under `config/` (o
 
 ## Default loading
 
-If `defaults.yml` has no `defaults.loading` section, Spine uses a built-in default: **`destination: local`** with **`storage_root: ".spine/local-output"`** (resolved relative to this config directory) and a placeholder **`prefix`**. [`defaults.example.yml`](defaults.example.yml) shows the same layout explicitly; switch that block to S3 (or set `destination`, `bucket`, and `prefix` per resource) for AWS object storage.
+If `defaults.yml` has no `defaults.loading` section, Spine uses a built-in default: **`destination: local`** with **`storage_root: ".spine/local-output"`** (resolved relative to the **repository root**: the directory that contains `src/`, so `.spine/` sits next to `config/` in a normal checkout) and a placeholder **`prefix`**. [`defaults.example.yml`](defaults.example.yml) shows the same layout explicitly; switch that block to S3 (or set `destination`, `bucket`, and `prefix` per resource) for AWS object storage.

--- a/config/README.md
+++ b/config/README.md
@@ -21,3 +21,7 @@ This directory holds **operator-local** YAML and SQL: `defaults.yml`, `sources/*
 ## `CONFIG_PATH`
 
 The environment variable `CONFIG_PATH` selects a subdirectory under `config/` (or an absolute path). The default `.` means this folder. See [`src/config/settings.py`](../src/config/settings.py) for resolution rules.
+
+## Default loading
+
+If `defaults.yml` has no `defaults.loading` section, Spine uses a built-in default: **`destination: local`** with **`storage_root: ".spine/local-output"`** (resolved relative to this config directory) and a placeholder **`prefix`**. [`defaults.example.yml`](defaults.example.yml) shows the same layout explicitly; switch that block to S3 (or set `destination`, `bucket`, and `prefix` per resource) for AWS object storage.

--- a/config/defaults.example.yml
+++ b/config/defaults.example.yml
@@ -6,12 +6,27 @@ defaults:
     initial_delay: 1
     backoff_factor: 2
 
+  # Default loading: local Delta under CONFIG_PATH/.spine/local-output (gitignored).
+  # Override per resource if needed, or replace this block with S3 (see commented example below).
   loading:
-    destination: "s3"
+    destination: "local"
     format: "delta"
     write_mode: "overwrite"
     compression: "snappy"
-    bucket: "${S3_INGESTION_BUCKET}"
+    storage_root: ".spine/local-output"
+    prefix: "default/output"
+
+  # For Amazon S3 instead, use something like:
+  # loading:
+  #   destination: "s3"
+  #   format: "delta"
+  #   write_mode: "overwrite"
+  #   compression: "snappy"
+  #   bucket: "${S3_INGESTION_BUCKET}"
+  #   prefix: "my_source/my_resource"
+  #
+  # If a resource sets only bucket/prefix, set destination: "s3" on that resource (or here
+  # in defaults) so it does not inherit destination: local from defaults.
 
   context:
     type: "redis"

--- a/config/defaults.example.yml
+++ b/config/defaults.example.yml
@@ -6,7 +6,8 @@ defaults:
     initial_delay: 1
     backoff_factor: 2
 
-  # Default loading: local Delta under CONFIG_PATH/.spine/local-output (gitignored).
+  # Default loading: local Delta; relative storage_root resolves under the repository
+  #   root (dir containing src/), e.g. repo/.spine/local-output (gitignored).
   # Override per resource if needed, or replace this block with S3 (see commented example below).
   loading:
     destination: "local"

--- a/docs/configuration/loading.md
+++ b/docs/configuration/loading.md
@@ -4,7 +4,7 @@
 
 - [Destinations](#destinations)
   - [Amazon S3](#amazon-s3)
-  - [Local filesystem (preview)](#local-filesystem-preview)
+  - [Local filesystem](#local-filesystem)
   - [Other object stores (preview)](#other-object-stores-preview)
 - [Delta Save Modes](#delta-save-modes)
   - [Overwrite](#overwrite)
@@ -14,7 +14,7 @@
 
 ## Destinations
 
-Loading uses Spark with Hadoop `FileSystem` URIs. Use **`destination: s3`** with **`bucket`** and **`prefix`** for Amazon S3, or **`destination: local`** with **`storage_root`** and **`prefix`** to write under a local directory as `file://` URIs (for example CI or on-prem without object storage).
+Loading uses Spark with Hadoop `FileSystem` URIs. Use **`destination: local`** with **`storage_root`** and **`prefix`** to write under a local directory as `file://` URIs, or **`destination: s3`** with **`bucket`** and **`prefix`** for Amazon S3. If your `defaults.yml` omits a `defaults.loading` block entirely, Spine applies a built-in default of **`destination: local`** with a relative **`storage_root`** under `.spine/local-output` and a placeholder **`prefix`**; copy [`config/defaults.example.yml`](../../config/defaults.example.yml) for an explicit starting point.
 
 Credentials and connectors follow your Spark deployment (for example IAM on AWS, or Hadoop `fs.*` settings for other schemes).
 
@@ -22,7 +22,7 @@ Credentials and connectors follow your Spark deployment (for example IAM on AWS,
 
 Use `destination: "s3"`, `bucket`, and `prefix` as in the examples below. `prefix` must look like `source_name/resource_name` (not a single segment).
 
-### Local filesystem (preview)
+### Local filesystem
 
 **`storage_root`** may be **absolute** or **relative**. Relative values are resolved when the operator config is loaded: they are joined to the **operator config directory** (the directory you pass as `CONFIG_PATH` / the folder that contains `defaults.yml`), not the process current working directory. That keeps paths portable across macOS, Linux, and Windows (paths are normalized with `pathlib` before Spark sees them).
 
@@ -112,7 +112,8 @@ loading:
 
 | `destination` | Required fields | Notes |
 |---------------|-----------------|--------|
-| `s3` | `bucket`, `prefix` | `prefix` uses the `source/resource` shape described above. |
+| `s3` | `bucket`, `prefix` | `prefix` uses the `source/resource` shape described above. Set **`destination: "s3"`** on the resource (or in defaults) whenever you set `bucket`; shallow merge with **`destination: local`** defaults would otherwise keep `local`. |
 | `local` | `storage_root`, `prefix` | `storage_root` may be absolute, or relative to the operator config directory (`CONFIG_PATH`, the folder that contains `defaults.yml`). Relative values are resolved when the config is loaded. |
+| *(omitted `defaults.loading`)* | *(built-in default)* | Same as **`local`** with relative **`storage_root: ".spine/local-output"`** and placeholder **`prefix: "default/output"`**; override per resource or in **`defaults.yml`**. |
 
 Filesystem helpers for loaders live under **`src/loader/`** (for example `object_store.py`, `local_storage.py`).

--- a/docs/configuration/loading.md
+++ b/docs/configuration/loading.md
@@ -2,14 +2,63 @@
 
 ## Table of Contents
 
+- [Destinations](#destinations)
+  - [Amazon S3](#amazon-s3)
+  - [Local filesystem (preview)](#local-filesystem-preview)
+  - [Other object stores (preview)](#other-object-stores-preview)
 - [Delta Save Modes](#delta-save-modes)
   - [Overwrite](#overwrite)
   - [Append](#append)
   - [Merge (Upsert)](#merge-upsert)
+- [Quick reference](#quick-reference)
+
+## Destinations
+
+Loading uses Spark with Hadoop `FileSystem` URIs. Use **`destination: s3`** with **`bucket`** and **`prefix`** for Amazon S3, or **`destination: local`** with **`storage_root`** and **`prefix`** to write under a local directory as `file://` URIs (for example CI or on-prem without object storage).
+
+Credentials and connectors follow your Spark deployment (for example IAM on AWS, or Hadoop `fs.*` settings for other schemes).
+
+### Amazon S3
+
+Use `destination: "s3"`, `bucket`, and `prefix` as in the examples below. `prefix` must look like `source_name/resource_name` (not a single segment).
+
+### Local filesystem (preview)
+
+**`storage_root`** may be **absolute** or **relative**. Relative values are resolved when the operator config is loaded: they are joined to the **operator config directory** (the directory you pass as `CONFIG_PATH` / the folder that contains `defaults.yml`), not the process current working directory. That keeps paths portable across macOS, Linux, and Windows (paths are normalized with `pathlib` before Spark sees them).
+
+The same `prefix`, `format`, `write_mode`, and `merge_keys` rules apply as for S3.
+
+**Recommended for dev/CI:** use a path under the repo that is gitignored, for example:
+
+```yaml
+loading:
+  destination: "local"
+  format: "delta"
+  write_mode: "overwrite"
+  storage_root: ".spine/local-output"
+  prefix: "source/resource"
+```
+
+For bind-mounted directories in containers, use an absolute path:
+
+```yaml
+loading:
+  destination: "local"
+  format: "delta"
+  write_mode: "overwrite"
+  storage_root: "/var/lib/spine/out"
+  prefix: "source/resource"
+```
+
+At startup validation, the **resolved** directory must already exist and be writable by the process. The check lives in `src/loader/local_storage.py` and runs from the handler during configuration validation.
+
+### Other object stores (preview)
+
+Spark can write to **`gs://`** or **`abfs://`** (and other schemes) when the correct Hadoop filesystem implementation and credentials are on the classpath and configured. Spine does not ship those connectors; operators add jars and Spark config as usual. Path and filesystem operations go through the Hadoop `FileSystem` layer in `src/loader/object_store.py`.
 
 ## Delta Save Modes
 
-When using Delta format, control how data is written to S3 with the `write_mode` option. Schema evolution is automatically enabled for all modes.
+When using Delta format, control how data is written with the `write_mode` option. Schema evolution is automatically enabled for all modes.
 
 **Available modes**: `overwrite` (default), `append`, `merge`
 
@@ -54,6 +103,16 @@ loading:
 ```
 
 **Notes**
+
 - `merge_keys` is required for merge mode (list of column names)
 - Supports composite keys (multiple columns)
 - Tables are created automatically if they don't exist
+
+## Quick reference
+
+| `destination` | Required fields | Notes |
+|---------------|-----------------|--------|
+| `s3` | `bucket`, `prefix` | `prefix` uses the `source/resource` shape described above. |
+| `local` | `storage_root`, `prefix` | `storage_root` may be absolute, or relative to the operator config directory (`CONFIG_PATH`, the folder that contains `defaults.yml`). Relative values are resolved when the config is loaded. |
+
+Filesystem helpers for loaders live under **`src/loader/`** (for example `object_store.py`, `local_storage.py`).

--- a/docs/configuration/loading.md
+++ b/docs/configuration/loading.md
@@ -14,7 +14,7 @@
 
 ## Destinations
 
-Loading uses Spark with Hadoop `FileSystem` URIs. Use **`destination: local`** with **`storage_root`** and **`prefix`** to write under a local directory as `file://` URIs, or **`destination: s3`** with **`bucket`** and **`prefix`** for Amazon S3. If your `defaults.yml` omits a `defaults.loading` block entirely, Spine applies a built-in default of **`destination: local`** with a relative **`storage_root`** under `.spine/local-output` and a placeholder **`prefix`**; copy [`config/defaults.example.yml`](../../config/defaults.example.yml) for an explicit starting point.
+Loading uses Spark with Hadoop `FileSystem` URIs. Use **`destination: local`** with **`storage_root`** and **`prefix`** to write under a local directory as `file://` URIs, or **`destination: s3`** with **`bucket`** and **`prefix`** for Amazon S3. If your `defaults.yml` omits a `defaults.loading` block entirely, Spine applies a built-in default of **`destination: local`** with relative **`storage_root: ".spine/local-output"`** (resolved under the **repository root**—the directory that contains `src/`—so in a normal checkout it lands next to `config/`) and a placeholder **`prefix`**; copy [`config/defaults.example.yml`](../../config/defaults.example.yml) for an explicit starting point.
 
 Credentials and connectors follow your Spark deployment (for example IAM on AWS, or Hadoop `fs.*` settings for other schemes).
 
@@ -24,7 +24,7 @@ Use `destination: "s3"`, `bucket`, and `prefix` as in the examples below. `prefi
 
 ### Local filesystem
 
-**`storage_root`** may be **absolute** or **relative**. Relative values are resolved when the operator config is loaded: they are joined to the **operator config directory** (the directory you pass as `CONFIG_PATH` / the folder that contains `defaults.yml`), not the process current working directory. That keeps paths portable across macOS, Linux, and Windows (paths are normalized with `pathlib` before Spark sees them).
+**`storage_root`** may be **absolute** or **relative**. Relative values are resolved when the operator config is loaded: they are joined to the **repository root** (the directory that contains `src/`), not to `CONFIG_PATH` or the process current working directory. For a normal checkout `.../myapp/config/`, output goes under `.../myapp/` (for example `.../myapp/.spine/local-output`), not under `config/`. If `CONFIG_PATH` points at YAML outside that tree (for example an absolute mount), relative `storage_root` still resolves under the Spine install root—use an absolute `storage_root` when output should live with that mount.
 
 The same `prefix`, `format`, `write_mode`, and `merge_keys` rules apply as for S3.
 
@@ -113,7 +113,7 @@ loading:
 | `destination` | Required fields | Notes |
 |---------------|-----------------|--------|
 | `s3` | `bucket`, `prefix` | `prefix` uses the `source/resource` shape described above. Set **`destination: "s3"`** on the resource (or in defaults) whenever you set `bucket`; shallow merge with **`destination: local`** defaults would otherwise keep `local`. |
-| `local` | `storage_root`, `prefix` | `storage_root` may be absolute, or relative to the operator config directory (`CONFIG_PATH`, the folder that contains `defaults.yml`). Relative values are resolved when the config is loaded. |
-| *(omitted `defaults.loading`)* | *(built-in default)* | Same as **`local`** with relative **`storage_root: ".spine/local-output"`** and placeholder **`prefix: "default/output"`**; override per resource or in **`defaults.yml`**. |
+| `local` | `storage_root`, `prefix` | `storage_root` may be absolute, or **relative to the repository root** (directory containing `src/`). Relative values are resolved when the config is loaded. |
+| *(omitted `defaults.loading`)* | *(built-in default)* | Same as **`local`** with **`storage_root: ".spine/local-output"`** (resolved under the repository root) and **`prefix: "default/output"`**; override per resource or in **`defaults.yml`**. |
 
 Filesystem helpers for loaders live under **`src/loader/`** (for example `object_store.py`, `local_storage.py`).

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -22,7 +22,7 @@ Python modules that load and validate this data live under `src/config/` (for ex
 
 Environment variable `CONFIG_PATH` (via pydantic-settings) selects which directory under `<repo_root>/config/` to load:
 
-- Default `.` → `<repo_root>/config/` (the `config/` folder at the project root).
+- Default `.` → `<repo_root>/config/` (the `config/` folder at the repository root).
 - Relative values → resolved under `<repo_root>/config/` (e.g. `staging` → `config/staging/`).
 - Absolute path → used as the pipeline config directory directly (for custom layouts or mounted volumes).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,7 +63,7 @@ For active development: customizing configs, debugging, or contributing.
 - Python 3.12+ and [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - **Java 17** (required for Spark)
 - Redis 7.0+ (for context management)
-- AWS credentials (for S3 access)
+- Loading destination credentials, if your configuration needs them (for example AWS when using **`destination: s3`**)
 - API credentials for your data sources
 
 ### Installation
@@ -177,5 +177,5 @@ python -m src.main --select jsonplaceholder --limit 5 --log-level TRACE
 | `--show-plan` | Show execution plan without validation or execution |
 | `--log-level` | Set log level (TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `--select` | Comma-separated source or `source:resource` selections |
-| `--limit` | Limit API requests per resource (0 = skip). When used, data is NOT saved to S3 |
+| `--limit` | Limit API requests per resource (0 = skip). When used, data is not written to the configured loading destination |
 | `--backfill`, `-b` | Force backfill date ranges instead of default dates |

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -10,6 +10,7 @@ import yaml
 from pydantic import ValidationError
 
 from src.config.config_models import PipelineConfig
+from src.config.repository_root import repository_root
 from src.utils.env_manager import resolve_env_var
 from src.utils.exceptions import ConfigError
 from src.utils.logger import get_logger
@@ -92,10 +93,8 @@ class ConfigLoader:
             # Resolve relative paths in disk_config (relative to config file/directory)
             raw_config = self._resolve_disk_config_paths(raw_config, path_for_disk)
 
-            # Resolve relative local loading storage_root against operator config directory
-            raw_config = self._resolve_local_loading_storage_paths(
-                raw_config, config_path.resolve()
-            )
+            # Resolve relative local loading storage_root against repository root (see repository_root)
+            raw_config = self._resolve_local_loading_storage_paths(raw_config)
 
             # Process configuration
             processed_config = self._process_config(raw_config)
@@ -309,15 +308,21 @@ class ConfigLoader:
         return config
 
     def _resolve_local_loading_storage_paths(
-        self, config: Dict[str, Any], config_root: Path
+        self, config: Dict[str, Any], layout_root: Optional[Path] = None
     ) -> Dict[str, Any]:
         """
         Resolve relative ``storage_root`` for ``destination: local`` loading configs.
 
-        Anchors to the operator config directory (same as ``PipelineConfig.config_root`` /
-        ``CONFIG_PATH``), not the process working directory.
+        Anchors to the **repository root** (directory containing ``src/``), independent
+        of where ``CONFIG_PATH`` points. In a normal checkout, ``.spine/local-output``
+        therefore sits next to ``config/`` under the repo. If operator YAML lives
+        elsewhere (absolute ``CONFIG_PATH``) and you want output beside that tree, use
+        an absolute ``storage_root``. Absolute ``storage_root`` values are unchanged.
+
+        ``layout_root``: optional override for tests; production uses
+        :func:`~src.config.repository_root.repository_root`.
         """
-        root = config_root.resolve()
+        root = (layout_root if layout_root is not None else repository_root()).resolve()
 
         def resolve_loading_dict(loading: Dict[str, Any]) -> None:
             if loading.get("destination") != "local":

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -92,6 +92,11 @@ class ConfigLoader:
             # Resolve relative paths in disk_config (relative to config file/directory)
             raw_config = self._resolve_disk_config_paths(raw_config, path_for_disk)
 
+            # Resolve relative local loading storage_root against operator config directory
+            raw_config = self._resolve_local_loading_storage_paths(
+                raw_config, config_path.resolve()
+            )
+
             # Process configuration
             processed_config = self._process_config(raw_config)
             processed_config["config_root"] = config_path.resolve()
@@ -300,6 +305,51 @@ class ConfigLoader:
                         # Only resolve if it's a relative path
                         if not Path(path).is_absolute():
                             disk_config["path"] = str(config_dir / path)
+
+        return config
+
+    def _resolve_local_loading_storage_paths(
+        self, config: Dict[str, Any], config_root: Path
+    ) -> Dict[str, Any]:
+        """
+        Resolve relative ``storage_root`` for ``destination: local`` loading configs.
+
+        Anchors to the operator config directory (same as ``PipelineConfig.config_root`` /
+        ``CONFIG_PATH``), not the process working directory.
+        """
+        root = config_root.resolve()
+
+        def resolve_loading_dict(loading: Dict[str, Any]) -> None:
+            if loading.get("destination") != "local":
+                return
+            sr = loading.get("storage_root")
+            if not isinstance(sr, str):
+                return
+            p = Path(sr).expanduser()
+            if p.is_absolute():
+                return
+            loading["storage_root"] = str((root / p).resolve())
+
+        defaults = config.get("defaults")
+        if isinstance(defaults, dict):
+            loading = defaults.get("loading")
+            if isinstance(loading, dict):
+                resolve_loading_dict(loading)
+
+        sources = config.get("sources", {})
+        if isinstance(sources, dict):
+            for _sn, source in sources.items():
+                if not isinstance(source, dict):
+                    continue
+                resources = source.get("resources", {})
+                if not isinstance(resources, dict):
+                    continue
+                for _rn, resource in resources.items():
+                    if not isinstance(resource, dict):
+                        continue
+                    loading = resource.get("loading")
+                    if isinstance(loading, dict):
+                        resolve_loading_dict(loading)
 
         return config
 

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -1208,16 +1208,24 @@ class StreamingConfig(BaseModel):
 
 
 class DefaultsConfig(BaseModel):
-    """Default configuration values."""
+    """Default configuration values. See ``config/defaults.example.yml`` for a full operator template."""
 
     retry: RetryConfig = Field(
         default_factory=RetryConfig, description="Default retry configuration"
     )
     loading: LoadingConfig = Field(
         default_factory=lambda: LoadingConfig(
-            destination="s3", format="parquet", compression="snappy"
+            destination="local",
+            format="delta",
+            write_mode="overwrite",
+            compression="snappy",
+            storage_root=".spine/local-output",
+            prefix="default/output",
         ),
-        description="Default loading configuration",
+        description=(
+            "Default loading when ``defaults.loading`` is omitted from YAML: local Delta under "
+            "``.spine/local-output`` (relative to CONFIG_PATH) with placeholder prefix; override for S3 or real paths."
+        ),
     )
     context: ContextConfig = Field(
         default_factory=ContextConfig, description="Context management configuration"

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -44,9 +44,9 @@ class RetryConfig(BaseModel):
 class LoadingConfig(BaseModel):
     """
     Data loading configuration.
-    For S3 destinations, prefix must be specified and should follow the pattern:
+    For S3 and local destinations, prefix must be specified and should follow the pattern:
     'source_name/resource_name' (e.g., 'my_source/users').
-    The actual data will be stored in a 'data' subdirectory under this prefix.
+    For S3, the actual Parquet data will be stored in a 'data' subdirectory under this prefix.
 
     Save modes for Delta format:
     - **overwrite** (default): Replace all existing data in the table
@@ -63,7 +63,14 @@ class LoadingConfig(BaseModel):
     write_mode: Literal["overwrite", "append", "merge", "ignore", "error"] = "overwrite"
     compression: Optional[str] = "snappy"
     bucket: Optional[str] = None  # For S3, can be inherited from defaults
-    prefix: Optional[str] = None  # For S3, required if destination is 's3'
+    prefix: Optional[str] = None  # For S3/local, required for those destinations
+    storage_root: Optional[str] = Field(
+        default=None,
+        description=(
+            "Filesystem directory for destination: local (Spark file://). "
+            "May be relative to CONFIG_PATH; ConfigLoader resolves it before validation."
+        ),
+    )
     merge_keys: Optional[List[str]] = Field(
         default=None,
         description="List of column names to use as primary keys for merge operations. Required when write_mode is 'merge'.",
@@ -76,11 +83,11 @@ class LoadingConfig(BaseModel):
     @field_validator("prefix")
     @classmethod
     def validate_prefix(cls, v: Optional[str], info: ValidationInfo) -> Optional[str]:
-        """Validate prefix format for S3 destinations."""
-        # Only validate if this is an S3 destination
-        if info.data.get("destination") == "s3":
+        """Validate prefix format for S3 and local filesystem destinations."""
+        dest = info.data.get("destination")
+        if dest in ("s3", "local"):
             if not v:
-                raise ValueError("prefix is required for S3 destinations")
+                raise ValueError(f"prefix is required for {dest} destinations")
 
             # Remove any leading/trailing slashes
             v = v.strip("/")
@@ -89,7 +96,7 @@ class LoadingConfig(BaseModel):
             parts = v.split("/")
             if len(parts) < 2:
                 raise ValueError(
-                    "S3 prefix must follow the pattern 'source_name/resource_name' "
+                    "prefix must follow the pattern 'source_name/resource_name' "
                     "(e.g., 'my_source/users')"
                 )
 
@@ -99,15 +106,6 @@ class LoadingConfig(BaseModel):
                     "prefix should not include 'data' directory - it will be automatically appended"
                 )
 
-        return v
-
-    @field_validator("bucket")
-    @classmethod
-    def validate_bucket(cls, v: Optional[str], info: ValidationInfo) -> Optional[str]:
-        """Validate bucket is present for S3 destinations."""
-        if info.data.get("destination") == "s3":
-            if not v:
-                raise ValueError("bucket is required for S3 destination")
         return v
 
     @model_validator(mode="after")
@@ -129,6 +127,17 @@ class LoadingConfig(BaseModel):
                 )
             if len(self.merge_keys) == 0:
                 raise ValueError("merge_keys must be a non-empty list when write_mode is 'merge'.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_destination_storage_fields(self) -> "LoadingConfig":
+        """Require bucket (S3) or storage_root (local); runs after merge_keys check."""
+        if self.destination == "s3":
+            if not self.bucket:
+                raise ValueError("bucket is required for S3 destination")
+        elif self.destination == "local":
+            if not self.storage_root:
+                raise ValueError("storage_root is required for local destination")
         return self
 
     model_config = {"validate_assignment": True}
@@ -1000,10 +1009,14 @@ class ResourceConfig(BaseModel):
 
         super().__init__(**data)
 
-        # Validate S3 configuration (only if loading is configured)
+        # Validate loading destination fields (only if loading is configured)
         if self.loading and self.loading.destination == "s3" and not self.loading.bucket:
             raise ValueError(
                 "bucket is required for S3 destination (either in defaults or resource configuration)"
+            )
+        if self.loading and self.loading.destination == "local" and not self.loading.storage_root:
+            raise ValueError(
+                "storage_root is required for local destination (either in defaults or resource configuration)"
             )
 
 

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -68,7 +68,8 @@ class LoadingConfig(BaseModel):
         default=None,
         description=(
             "Filesystem directory for destination: local (Spark file://). "
-            "May be relative to CONFIG_PATH; ConfigLoader resolves it before validation."
+            "May be relative to the repository root (directory containing ``src/``); "
+            "ConfigLoader resolves it before validation."
         ),
     )
     merge_keys: Optional[List[str]] = Field(
@@ -1224,7 +1225,8 @@ class DefaultsConfig(BaseModel):
         ),
         description=(
             "Default loading when ``defaults.loading`` is omitted from YAML: local Delta under "
-            "``.spine/local-output`` (relative to CONFIG_PATH) with placeholder prefix; override for S3 or real paths."
+            "``.spine/local-output`` (relative to the repository root, next to ``config/`` in a normal checkout) "
+            "with placeholder prefix; override for S3 or real paths."
         ),
     )
     context: ContextConfig = Field(

--- a/src/config/repository_root.py
+++ b/src/config/repository_root.py
@@ -1,0 +1,17 @@
+"""
+Canonical filesystem root for the Spine tree (directory that contains ``src/``).
+
+This is derived only from the location of this package on disk, not from
+``CONFIG_PATH``, the process working directory, or where operator YAML lives.
+Operator config may live elsewhere (absolute ``CONFIG_PATH``); local loading
+paths that are relative still resolve under this root unless you use an
+absolute ``storage_root``.
+"""
+
+from pathlib import Path
+
+
+def repository_root() -> Path:
+    """Return the repository root: parent of ``src/`` (contains ``src/``, ``config/``, etc.)."""
+    # This file lives at ``<root>/src/config/repository_root.py``.
+    return Path(__file__).resolve().parents[2]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -12,17 +12,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from src.config.config_loader import ConfigLoader
 from src.config.config_models import PipelineConfig
+from src.config.repository_root import repository_root
 from src.utils.aws_credentials import AWSCredentialManager
 from src.utils.exceptions import AWSError, ConfigError
 from src.utils.logger import get_logger
 
 # Initialize logger
 logger = get_logger(__name__)
-
-
-def _repository_root() -> Path:
-    """Parent of `src/` (directory that contains `config/` and `src/`)."""
-    return Path(__file__).resolve().parents[2]
 
 
 def _resolve_pipeline_config_dir(config_path_setting: str) -> Path:
@@ -35,7 +31,7 @@ def _resolve_pipeline_config_dir(config_path_setting: str) -> Path:
     raw = Path(config_path_setting)
     if raw.is_absolute():
         return raw.resolve()
-    return (_repository_root() / "config" / raw).resolve()
+    return (repository_root() / "config" / raw).resolve()
 
 
 class SparkSettings(BaseSettings):

--- a/src/handler/base_handler.py
+++ b/src/handler/base_handler.py
@@ -5,12 +5,14 @@ Base handler class providing common orchestration functionality.
 import time
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 from src.loader.base_loader import BaseLoader
+from src.loader.local_storage import check_local_storage_root
 from src.utils.exceptions import HandlerError, SparkError
 from src.utils.logger import get_logger
 from src.utils.spark_manager import SparkManager
@@ -120,6 +122,18 @@ class BaseHandler(ABC):
             if not isinstance(e, HandlerError):
                 raise HandlerError.from_error(e, "S3 connectivity test failed") from e
             raise
+
+    def _test_local_storage_writable(self, storage_root: str) -> None:
+        """
+        Verify local filesystem loading root exists as a directory and is writable.
+
+        Args:
+            storage_root: Resolved filesystem path from loading configuration
+
+        Raises:
+            HandlerError: If the path is not a writable directory
+        """
+        check_local_storage_root(Path(storage_root))
 
     def with_retry(
         self,

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -2514,8 +2514,9 @@ class DynamicHandler(BaseHandler):
                 },
             )
 
-            # Track unique S3 buckets to validate
-            s3_buckets = set()
+            # Track unique S3 buckets and local storage roots to validate
+            s3_buckets: set[str] = set()
+            local_storage_roots: set[str] = set()
 
             # Get the list of sources that are actually part of the execution plan
             selected_sources = {
@@ -2558,12 +2559,21 @@ class DynamicHandler(BaseHandler):
                                     f"Missing S3 bucket configuration for resource: {resource_name}"
                                 )
                             s3_buckets.add(resource_config.loading.bucket)
+                        elif resource_config.loading.destination == "local":
+                            if not resource_config.loading.storage_root:
+                                raise HandlerError(
+                                    f"Missing storage_root for local loading on resource: {resource_name}"
+                                )
+                            local_storage_roots.add(resource_config.loading.storage_root)
 
                 self.logger.info(f"Successfully validated source: {source_name}")
 
             # Test S3 connectivity for all unique buckets
             for bucket in s3_buckets:
                 self._test_s3_connectivity(bucket)
+
+            for storage_root in local_storage_roots:
+                self._test_local_storage_writable(storage_root)
 
             self.logger.info("Configuration validation completed successfully")
 

--- a/src/loader/__init__.py
+++ b/src/loader/__init__.py
@@ -1,0 +1,5 @@
+"""Data loaders and filesystem helpers for Spark destinations."""
+
+from src.loader.object_store import ObjectStore, SparkFilesystemObjectStore, loading_base_uri
+
+__all__ = ["ObjectStore", "SparkFilesystemObjectStore", "loading_base_uri"]

--- a/src/loader/loader_factory.py
+++ b/src/loader/loader_factory.py
@@ -13,7 +13,10 @@ class LoaderFactory:
     """Factory for creating loader instances."""
 
     # Map of loader types to their implementations
-    _loader_types: ClassVar[Dict[str, Type[BaseLoader]]] = {"s3": S3Loader}
+    _loader_types: ClassVar[Dict[str, Type[BaseLoader]]] = {
+        "s3": S3Loader,
+        "local": S3Loader,
+    }
 
     @classmethod
     def create_loader(cls, config: LoadingConfig) -> BaseLoader:

--- a/src/loader/local_storage.py
+++ b/src/loader/local_storage.py
@@ -1,0 +1,24 @@
+"""Local filesystem checks for loading destinations (no Spark required)."""
+
+import os
+from pathlib import Path
+
+from src.utils.exceptions import HandlerError
+from src.utils.logger import get_logger
+
+_logger = get_logger(__name__)
+
+
+def check_local_storage_root(path: Path) -> None:
+    """
+    Ensure ``path`` exists as a directory and is writable (POSIX ``W_OK``).
+
+    Raises:
+        HandlerError: If the path is not a writable directory
+    """
+    p = path.expanduser().resolve()
+    if not p.is_dir():
+        raise HandlerError(f"Local loading storage_root is not a directory: {p}")
+    if not os.access(p, os.W_OK):
+        raise HandlerError(f"Local loading storage_root is not writable: {p}")
+    _logger.debug("Successfully validated local storage access", extra_fields={"path": str(p)})

--- a/src/loader/object_store.py
+++ b/src/loader/object_store.py
@@ -1,0 +1,119 @@
+"""Spark-backed Hadoop FileSystem operations and loading base URI resolution."""
+
+from pathlib import Path
+from typing import Optional, Protocol, runtime_checkable
+
+from pyspark.sql import SparkSession
+
+from src.utils.exceptions import LoaderError
+
+
+def loading_base_uri(
+    *,
+    destination: str,
+    bucket: Optional[str] = None,
+    storage_root: Optional[str] = None,
+) -> str:
+    """
+    Return the authority + path prefix URI for Spark writes (no trailing slash).
+
+    - ``s3`` → ``s3a://{bucket}``
+    - ``local`` → ``file:///...`` from resolved ``storage_root`` (should be absolute
+      after config load; relative values resolve against the process current working directory).
+    """
+    if destination == "s3":
+        if not bucket:
+            raise ValueError("bucket is required for S3 loading destination")
+        return f"s3a://{bucket.strip().strip('/')}"
+    if destination == "local":
+        if not storage_root:
+            raise ValueError("storage_root is required for local loading destination")
+        root = Path(storage_root).expanduser().resolve()
+        return root.as_uri().rstrip("/")
+    raise ValueError(f"Unsupported loading destination: {destination!r}")
+
+
+@runtime_checkable
+class ObjectStore(Protocol):
+    """Narrow seam for URI-based paths used by Spark loaders (s3a, file, gs, abfs, …)."""
+
+    def resolve_path(self, base_uri: str, *segments: str, trailing_slash: bool = False) -> str:
+        """Join base URI with path segments; optional trailing slash for directory roots."""
+        ...
+
+    def exists(self, uri: str) -> bool: ...
+
+    def delete(self, uri: str, *, recursive: bool = True) -> None: ...
+
+    def move(self, src_uri: str, dst_uri: str) -> None: ...
+
+    def glob_first_part_file(self, dir_uri: str) -> Optional[str]:
+        """Return the Hadoop path string of the first ``part-*`` under ``dir_uri``, or None."""
+        ...
+
+    def is_empty_directory(self, uri: str) -> bool:
+        """True if path is missing, or exists as a directory with no children."""
+        ...
+
+
+class SparkFilesystemObjectStore:
+    """Object store backed by Spark's JVM Hadoop FileSystem (per-URI scheme)."""
+
+    def __init__(self, spark: SparkSession) -> None:
+        self._spark = spark
+
+    def resolve_path(self, base_uri: str, *segments: str, trailing_slash: bool = False) -> str:
+        base = base_uri.rstrip("/")
+        parts = [s.strip("/") for s in segments if s and s.strip("/")]
+        if parts:
+            out = base + "/" + "/".join(parts)
+        else:
+            out = base
+        if trailing_slash and not out.endswith("/"):
+            out += "/"
+        return out
+
+    def exists(self, uri: str) -> bool:
+        jvm = self._spark.sparkContext._jvm
+        hadoop_conf = self._spark.sparkContext._jsc.hadoopConfiguration()
+        path = jvm.org.apache.hadoop.fs.Path(uri)
+        fs = jvm.org.apache.hadoop.fs.FileSystem.get(path.toUri(), hadoop_conf)
+        return bool(fs.exists(path))
+
+    def delete(self, uri: str, *, recursive: bool = True) -> None:
+        jvm = self._spark.sparkContext._jvm
+        hadoop_conf = self._spark.sparkContext._jsc.hadoopConfiguration()
+        path = jvm.org.apache.hadoop.fs.Path(uri)
+        fs = jvm.org.apache.hadoop.fs.FileSystem.get(path.toUri(), hadoop_conf)
+        if fs.exists(path):
+            fs.delete(path, recursive)
+
+    def move(self, src_uri: str, dst_uri: str) -> None:
+        jvm = self._spark.sparkContext._jvm
+        hadoop_conf = self._spark.sparkContext._jsc.hadoopConfiguration()
+        src = jvm.org.apache.hadoop.fs.Path(src_uri)
+        dst = jvm.org.apache.hadoop.fs.Path(dst_uri)
+        fs = jvm.org.apache.hadoop.fs.FileSystem.get(src.toUri(), hadoop_conf)
+        if not fs.rename(src, dst):
+            raise LoaderError(f"Failed to move file from {src_uri} to {dst_uri}")
+
+    def glob_first_part_file(self, dir_uri: str) -> Optional[str]:
+        jvm = self._spark.sparkContext._jvm
+        hadoop_conf = self._spark.sparkContext._jsc.hadoopConfiguration()
+        glob_path = jvm.org.apache.hadoop.fs.Path(f"{dir_uri.rstrip('/')}/part-*")
+        fs = jvm.org.apache.hadoop.fs.FileSystem.get(glob_path.toUri(), hadoop_conf)
+        statuses = fs.globStatus(glob_path)
+        if not statuses or len(statuses) == 0:
+            return None
+        return str(statuses[0].getPath().toString())
+
+    def is_empty_directory(self, uri: str) -> bool:
+        jvm = self._spark.sparkContext._jvm
+        hadoop_conf = self._spark.sparkContext._jsc.hadoopConfiguration()
+        path = jvm.org.apache.hadoop.fs.Path(uri)
+        fs = jvm.org.apache.hadoop.fs.FileSystem.get(path.toUri(), hadoop_conf)
+        if not fs.exists(path):
+            return True
+        if not fs.isDirectory(path):
+            return False
+        return len(fs.listStatus(path)) == 0

--- a/src/loader/object_store.py
+++ b/src/loader/object_store.py
@@ -18,8 +18,10 @@ def loading_base_uri(
     Return the authority + path prefix URI for Spark writes (no trailing slash).
 
     - ``s3`` → ``s3a://{bucket}``
-    - ``local`` → ``file:///...`` from resolved ``storage_root`` (should be absolute
-      after config load; relative values resolve against the process current working directory).
+    - ``local`` → ``file:///...`` from resolved ``storage_root``. After ``ConfigLoader``
+      runs, ``storage_root`` is absolute (relative paths are anchored to the repository
+      root: the directory containing ``src/``). Constructing ``LoadingConfig`` without the
+      loader resolves relative paths against the current working directory instead.
     """
     if destination == "s3":
         if not bucket:

--- a/src/loader/s3_loader.py
+++ b/src/loader/s3_loader.py
@@ -14,6 +14,7 @@ from pyspark.sql.types import StructField, StructType
 
 from src.config.config_models import LoadingConfig
 from src.loader.base_loader import BaseLoader, LoaderError
+from src.loader.object_store import SparkFilesystemObjectStore, loading_base_uri
 from src.utils.logger import get_logger
 
 
@@ -46,12 +47,13 @@ def retry_on_s3_error(max_retries: int = 3, delay: float = 1.0):
 
 
 class S3Loader(BaseLoader):
-    """Loader for AWS S3 destinations using Spark."""
+    """Loader for object storage destinations (S3, local, …) using Spark and Hadoop FileSystem."""
 
     def __init__(self):
         """Initialize the S3 loader."""
         super().__init__()
         self.spark = None
+        self._object_store: Optional[SparkFilesystemObjectStore] = None
 
     def set_spark_session(self, spark: SparkSession) -> None:
         """
@@ -61,25 +63,13 @@ class S3Loader(BaseLoader):
             spark: SparkSession to use
         """
         self.spark = spark
+        self._object_store = SparkFilesystemObjectStore(spark) if spark is not None else None
 
-    def _get_s3_filesystem(self, bucket: str):
-        """
-        Get S3 filesystem instance.
-
-        Args:
-            bucket: S3 bucket name
-
-        Returns:
-            Tuple[FileSystem, Configuration]: S3 filesystem and Hadoop configuration
-        """
-        if not self.spark:
+    @property
+    def object_store(self) -> SparkFilesystemObjectStore:
+        if not self.spark or not self._object_store:
             raise LoaderError("Spark session not set. Call set_spark_session first.")
-
-        hadoop_conf = self.spark.sparkContext._jsc.hadoopConfiguration()
-        fs = self.spark.sparkContext._jvm.org.apache.hadoop.fs.FileSystem.get(
-            self.spark.sparkContext._jvm.java.net.URI(f"s3a://{bucket}"), hadoop_conf
-        )
-        return fs, hadoop_conf
+        return self._object_store
 
     def _format_prefix(self, prefix: Optional[str]) -> str:
         """
@@ -99,40 +89,43 @@ class S3Loader(BaseLoader):
         clean_prefix = prefix.strip("/")
         return f"{clean_prefix}/data"
 
-    def _generate_temp_path(self, bucket: str, prefix: str, key: str) -> str:
+    def _generate_temp_path(self, base_uri: str, prefix: str, key: str) -> str:
         """
         Generate temporary path for initial write.
 
         Args:
-            bucket: S3 bucket name
+            base_uri: Filesystem base URI (e.g. s3a://bucket or file:///path)
             prefix: Key prefix
             key: Final key name
 
         Returns:
-            str: Temporary S3 path
+            str: Temporary path URI
         """
         clean_prefix = self._format_prefix(prefix)
-        return f"s3a://{bucket}/{clean_prefix}/_temp/spark_writes/{key}"
+        return self.object_store.resolve_path(
+            base_uri, clean_prefix, "_temp", "spark_writes", key, trailing_slash=False
+        )
 
     def _generate_final_path(
-        self, bucket: str, prefix: str, extension: str = "parquet"
+        self, base_uri: str, prefix: str, extension: str = "parquet"
     ) -> Tuple[str, str]:
         """
-        Generate final S3 path with timestamp and UUID for file-based formats (e.g., Parquet).
+        Generate final path with timestamp and UUID for file-based formats (e.g., Parquet).
 
         Args:
-            bucket: S3 bucket name
+            base_uri: Filesystem base URI
             prefix: Key prefix
             extension: File extension
 
         Returns:
-            tuple[str, str]: Final S3 path and key
+            tuple[str, str]: Final path URI and key
         """
         timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
         unique_id = str(uuid.uuid4())
         clean_prefix = self._format_prefix(prefix)
         key = f"{timestamp}_{unique_id}.{extension}"
-        return f"s3a://{bucket}/{clean_prefix}/{key}", key
+        final = self.object_store.resolve_path(base_uri, clean_prefix, key)
+        return final, key
 
     def _get_source_type_prefix(self, source_type: Optional[str]) -> str:
         """
@@ -190,7 +183,7 @@ class S3Loader(BaseLoader):
             return source_type_prefix
 
     def _generate_delta_path(
-        self, bucket: str, prefix: str, source_type: Optional[str] = None
+        self, base_uri: str, prefix: str, source_type: Optional[str] = None
     ) -> str:
         """
         Generate Delta table path (directory-based, not file-based).
@@ -201,7 +194,7 @@ class S3Loader(BaseLoader):
         The source type prefix is prepended automatically.
 
         Args:
-            bucket: S3 bucket name
+            base_uri: Filesystem base URI
             prefix: Key prefix
             source_type: Optional source type to prepend to the path
 
@@ -217,7 +210,9 @@ class S3Loader(BaseLoader):
         else:
             clean_prefix = full_prefix.strip("/")
         # Delta tables are directories, so we return the directory path
-        return f"s3a://{bucket}/{clean_prefix}/" if clean_prefix else f"s3a://{bucket}/"
+        if clean_prefix:
+            return self.object_store.resolve_path(base_uri, clean_prefix, trailing_slash=True)
+        return self.object_store.resolve_path(base_uri, trailing_slash=True)
 
     def _ensure_dataframe(
         self, data: Union[DataFrame, List[Dict[str, Any]]], schema: Optional[StructType] = None
@@ -378,33 +373,28 @@ class S3Loader(BaseLoader):
 
         writer.save(path)
 
-    def _cleanup_temp_dir(self, fs, temp_path: str) -> None:
+    def _cleanup_temp_dir(self, store: SparkFilesystemObjectStore, temp_path: str) -> None:
         """
         Clean up temporary directory structure.
         Deletes the temp write directory and its parent directories if empty.
 
         Args:
-            fs: Hadoop FileSystem instance
-            temp_path: Path to temporary directory
+            store: Object store for delete/exists checks
+            temp_path: Path to temporary directory (URI string)
         """
         try:
             jvm = self.spark.sparkContext._jvm
             temp_path_obj = jvm.org.apache.hadoop.fs.Path(temp_path)
 
-            # Delete temp write directory
-            fs.delete(temp_path_obj, True)
+            store.delete(temp_path, recursive=True)
 
-            # Delete parent directories if empty
-            spark_writes = temp_path_obj.getParent()
-            temp_dir = spark_writes.getParent()
+            spark_writes = str(temp_path_obj.getParent().toString())
+            temp_dir = str(temp_path_obj.getParent().getParent().toString())
 
-            # Check and delete spark_writes directory
-            if fs.exists(spark_writes) and len(fs.listStatus(spark_writes)) == 0:
-                fs.delete(spark_writes, True)
-
-                # Check and delete _temp directory if empty
-                if fs.exists(temp_dir) and len(fs.listStatus(temp_dir)) == 0:
-                    fs.delete(temp_dir, True)
+            if store.is_empty_directory(spark_writes):
+                store.delete(spark_writes, recursive=True)
+                if store.is_empty_directory(temp_dir):
+                    store.delete(temp_dir, recursive=True)
 
             self.logger.trace(
                 "Cleaned up temporary directories", extra_fields={"temp_path": temp_path}
@@ -417,10 +407,9 @@ class S3Loader(BaseLoader):
             )
 
     @retry_on_s3_error()
-    def _move_file(self, fs, src_path, dst_path) -> None:
+    def _move_uri(self, store: SparkFilesystemObjectStore, src_uri: str, dst_uri: str) -> None:
         """Move file from temp to final location with retry logic."""
-        if not fs.rename(src_path, dst_path):
-            raise LoaderError(f"Failed to move file from {src_path} to {dst_path}")
+        store.move(src_uri, dst_uri)
 
     def load(
         self,
@@ -451,13 +440,20 @@ class S3Loader(BaseLoader):
         if not self.spark:
             raise LoaderError("Spark session not set. Call set_spark_session first.")
 
-        if not config.bucket:
-            raise LoaderError("S3 bucket must be specified in configuration")
+        try:
+            base_uri = loading_base_uri(
+                destination=config.destination,
+                bucket=config.bucket,
+                storage_root=config.storage_root,
+            )
+        except ValueError as e:
+            raise LoaderError(str(e)) from e
 
         self.logger.debug(
-            "Starting S3 data load",
+            "Starting object store data load",
             extra_fields={
-                "bucket": config.bucket,
+                "destination": config.destination,
+                "base_uri": base_uri,
                 "format": config.format,
                 "write_mode": config.write_mode,
                 "input_type": type(data).__name__,
@@ -478,10 +474,14 @@ class S3Loader(BaseLoader):
         # Branch based on format type
         if config.format == "delta":
             # Delta format: write directly to final directory location
-            return self._load_delta(df, config, source_type=source_type, **kwargs)
+            return self._load_delta(
+                df, config, base_uri=base_uri, source_type=source_type, **kwargs
+            )
         else:
             # Parquet or other file-based formats: use existing file-based logic
-            return self._load_file_based(df, config, source_type=source_type, **kwargs)
+            return self._load_file_based(
+                df, config, base_uri=base_uri, source_type=source_type, **kwargs
+            )
 
     def _delta_table_exists(self, path: str) -> bool:
         """
@@ -491,7 +491,7 @@ class S3Loader(BaseLoader):
         for a valid Delta table.
 
         Args:
-            path: S3 path to the Delta table
+            path: URI path to the Delta table
 
         Returns:
             bool: True if Delta table exists, False otherwise
@@ -504,19 +504,9 @@ class S3Loader(BaseLoader):
                 )
                 return False
 
-            # Check if _delta_log directory exists (required for Delta table)
-            # Delta tables always have a _delta_log directory
-            jvm = self.spark.sparkContext._jvm
-            delta_log_path = jvm.org.apache.hadoop.fs.Path(f"{path}/_delta_log")
-
-            # Get filesystem for the path
-            hadoop_conf = self.spark.sparkContext._jsc.hadoopConfiguration()
-            uri = jvm.java.net.URI(path)
-            fs = jvm.org.apache.hadoop.fs.FileSystem.get(uri, hadoop_conf)
-
-            # Check if _delta_log directory exists
-            exists = fs.exists(delta_log_path)
-            return exists
+            store = self.object_store
+            delta_log = store.resolve_path(path.rstrip("/"), "_delta_log")
+            return store.exists(delta_log)
 
         except Exception as e:
             # If any error occurs, assume table doesn't exist
@@ -543,16 +533,27 @@ class S3Loader(BaseLoader):
 
         Returns:
             True if the Delta table exists at the configured path, False otherwise.
-            Returns False if destination is not s3, format is not delta, or bucket/prefix missing.
+            Returns False if destination is not object-store backed, format is not delta,
+            or required path fields are missing.
         """
-        if config.destination != "s3" or config.format != "delta":
+        if config.destination not in ("s3", "local") or config.format != "delta":
             return False
-        if not config.bucket or not config.prefix:
+        if config.destination == "s3" and (not config.bucket or not config.prefix):
+            return False
+        if config.destination == "local" and (not config.storage_root or not config.prefix):
             return False
         if not self.spark:
             return False
+        try:
+            base_uri = loading_base_uri(
+                destination=config.destination,
+                bucket=config.bucket,
+                storage_root=config.storage_root,
+            )
+        except ValueError:
+            return False
         path = self._generate_delta_path(
-            bucket=config.bucket,
+            base_uri=base_uri,
             prefix=config.prefix,
             source_type=source_type,
         )
@@ -803,7 +804,13 @@ class S3Loader(BaseLoader):
             raise LoaderError(error_msg) from e
 
     def _load_delta(
-        self, df: DataFrame, config: LoadingConfig, source_type: Optional[str] = None, **kwargs
+        self,
+        df: DataFrame,
+        config: LoadingConfig,
+        *,
+        base_uri: str,
+        source_type: Optional[str] = None,
+        **kwargs,
     ) -> str:
         """
         Load data as Delta table to S3 with support for multiple save modes.
@@ -848,11 +855,11 @@ class S3Loader(BaseLoader):
             # For Delta, we use the prefix directly without "data/" suffix
             # Source type prefix is automatically prepended
             final_path = self._generate_delta_path(
-                bucket=config.bucket, prefix=config.prefix, source_type=source_type
+                base_uri=base_uri, prefix=config.prefix, source_type=source_type
             )
 
             self.logger.trace(
-                "Writing Delta table to S3",
+                "Writing Delta table",
                 extra_fields={
                     "delta_path": final_path,
                     "write_mode": config.write_mode,
@@ -928,7 +935,7 @@ class S3Loader(BaseLoader):
                 self._write_dataframe(df, final_path, write_options)
 
             self.logger.info(
-                "Successfully loaded Delta table to S3",
+                "Successfully loaded Delta table",
                 extra_fields={
                     "destination": final_path,
                     "write_mode": config.write_mode,
@@ -939,12 +946,12 @@ class S3Loader(BaseLoader):
             return final_path
 
         except Exception as e:
-            error_msg = f"Failed to load Delta table to S3: {e!s}"
+            error_msg = f"Failed to load Delta table: {e!s}"
             self.logger.error(
                 error_msg,
                 extra_fields={
                     "error": str(e),
-                    "bucket": config.bucket,
+                    "destination": config.destination,
                     "prefix": config.prefix,
                     "write_mode": config.write_mode,
                 },
@@ -952,7 +959,13 @@ class S3Loader(BaseLoader):
             raise LoaderError(error_msg) from e
 
     def _load_file_based(
-        self, df: DataFrame, config: LoadingConfig, source_type: Optional[str] = None, **kwargs
+        self,
+        df: DataFrame,
+        config: LoadingConfig,
+        *,
+        base_uri: str,
+        source_type: Optional[str] = None,
+        **kwargs,
     ) -> str:
         """
         Load data as file-based format (e.g., Parquet) to S3.
@@ -974,12 +987,10 @@ class S3Loader(BaseLoader):
 
             # Generate paths for file-based format
             final_path, key = self._generate_final_path(
-                bucket=config.bucket, prefix=prefixed_prefix, extension=config.format
+                base_uri=base_uri, prefix=prefixed_prefix, extension=config.format
             )
 
-            temp_path = self._generate_temp_path(
-                bucket=config.bucket, prefix=prefixed_prefix, key=key
-            )
+            temp_path = self._generate_temp_path(base_uri=base_uri, prefix=prefixed_prefix, key=key)
 
             # Prepare write options
             write_options = {
@@ -1003,34 +1014,25 @@ class S3Loader(BaseLoader):
 
             # Move file to final location
             try:
-                fs, _ = self._get_s3_filesystem(config.bucket)
-
-                # Find the part file
-                temp_files = fs.globStatus(
-                    self.spark.sparkContext._jvm.org.apache.hadoop.fs.Path(f"{temp_path}/part-*")
-                )
-
-                if not temp_files or len(temp_files) == 0:
+                store = self.object_store
+                part_uri = store.glob_first_part_file(temp_path)
+                if not part_uri:
                     raise LoaderError(f"No part file found in temporary location: {temp_path}")
-
-                # Move the file
-                src_path = temp_files[0].getPath()
-                dst_path = self.spark.sparkContext._jvm.org.apache.hadoop.fs.Path(final_path)
 
                 self.logger.debug(
                     "Moving file to final location", extra_fields={"destination": final_path}
                 )
 
-                self._move_file(fs, src_path, dst_path)
+                self._move_uri(store, part_uri, final_path)
 
                 # Clean up temp directory
-                self._cleanup_temp_dir(fs, temp_path)
+                self._cleanup_temp_dir(store, temp_path)
 
             except Exception as e:
                 raise LoaderError(f"Failed to move file to final destination: {e!s}") from e
 
             self.logger.info(
-                "Successfully loaded data to S3",
+                "Successfully loaded data",
                 extra_fields={
                     "destination": final_path,
                     "format": config.format,
@@ -1044,17 +1046,20 @@ class S3Loader(BaseLoader):
             # Attempt to clean up temp directory if it exists
             if temp_path:
                 try:
-                    fs, _ = self._get_s3_filesystem(config.bucket)
-                    self._cleanup_temp_dir(fs, temp_path)
+                    self._cleanup_temp_dir(self.object_store, temp_path)
                 except Exception as cleanup_error:
                     self.logger.warning(
                         "Failed to clean up temporary directory after error",
                         extra_fields={"temp_path": temp_path, "error": str(cleanup_error)},
                     )
 
-            error_msg = f"Failed to load data to S3: {e!s}"
+            error_msg = f"Failed to load data: {e!s}"
             self.logger.error(
                 error_msg,
-                extra_fields={"error": str(e), "bucket": config.bucket, "format": config.format},
+                extra_fields={
+                    "error": str(e),
+                    "destination": config.destination,
+                    "format": config.format,
+                },
             )
             raise LoaderError(error_msg) from e

--- a/src/utils/s3_config_push.py
+++ b/src/utils/s3_config_push.py
@@ -19,6 +19,8 @@ from typing import Iterable, Iterator, Tuple
 import boto3
 from botocore.exceptions import ClientError
 
+from src.config.repository_root import repository_root
+
 __all__ = ["iter_operator_config_files", "parse_s3_uri", "push_config_to_s3"]
 
 _EXCLUDED_BASENAMES = {"README.md", ".gitkeep"}
@@ -26,10 +28,6 @@ _INCLUDED_SUBTREES: tuple[tuple[str, str], ...] = (
     ("sources/", ".yml"),
     ("queries/", ".sql"),
 )
-
-
-def _repository_root() -> Path:
-    return Path(__file__).resolve().parents[2]
 
 
 def resolve_local_config_root(config_path: str | None = None) -> Path:
@@ -41,7 +39,7 @@ def resolve_local_config_root(config_path: str | None = None) -> Path:
     p = Path(raw)
     if p.is_absolute():
         return p.resolve()
-    return (_repository_root() / "config" / p).resolve()
+    return (repository_root() / "config" / p).resolve()
 
 
 def parse_s3_uri(uri: str) -> Tuple[str, str]:

--- a/tests/test_config/test_config_loader_local_storage.py
+++ b/tests/test_config/test_config_loader_local_storage.py
@@ -1,0 +1,74 @@
+"""Tests for resolving local loading storage_root in ConfigLoader."""
+
+from pathlib import Path
+
+from src.config.config_loader import ConfigLoader
+
+
+def test_resolve_local_loading_storage_paths_relative_defaults() -> None:
+    loader = ConfigLoader()
+    cfg = {
+        "defaults": {
+            "loading": {
+                "destination": "local",
+                "storage_root": ".spine/local-output",
+                "prefix": "src/res",
+            }
+        }
+    }
+    config_root = Path("/tmp/spine_cfg")
+    loader._resolve_local_loading_storage_paths(cfg, config_root)
+    assert cfg["defaults"]["loading"]["storage_root"] == str(
+        (config_root / ".spine/local-output").resolve()
+    )
+
+
+def test_resolve_local_loading_storage_paths_absolute_unchanged() -> None:
+    loader = ConfigLoader()
+    cfg = {
+        "defaults": {
+            "loading": {
+                "destination": "local",
+                "storage_root": "/var/data",
+                "prefix": "src/res",
+            }
+        }
+    }
+    loader._resolve_local_loading_storage_paths(cfg, Path("/tmp/any"))
+    assert cfg["defaults"]["loading"]["storage_root"] == "/var/data"
+
+
+def test_resolve_local_loading_storage_paths_skips_s3() -> None:
+    loader = ConfigLoader()
+    cfg = {"defaults": {"loading": {"destination": "s3", "storage_root": "rel", "prefix": "a/b"}}}
+    loader._resolve_local_loading_storage_paths(cfg, Path("/tmp/c"))
+    assert cfg["defaults"]["loading"]["storage_root"] == "rel"
+
+
+def test_resolve_local_loading_storage_paths_resource(tmp_path: Path) -> None:
+    loader = ConfigLoader()
+    cfg = {
+        "defaults": {},
+        "sources": {
+            "api": {
+                "type": "rest_api",
+                "resources": {
+                    "r1": {
+                        "method": "GET",
+                        "path": "/x",
+                        "loading": {
+                            "destination": "local",
+                            "storage_root": "out/data",
+                            "prefix": "a/b",
+                        },
+                    }
+                },
+            }
+        },
+    }
+    root = tmp_path / "cfgdir"
+    root.mkdir()
+    loader._resolve_local_loading_storage_paths(cfg, root.resolve())
+    assert cfg["sources"]["api"]["resources"]["r1"]["loading"]["storage_root"] == str(
+        (root / "out/data").resolve()
+    )

--- a/tests/test_config/test_config_loader_local_storage.py
+++ b/tests/test_config/test_config_loader_local_storage.py
@@ -16,10 +16,10 @@ def test_resolve_local_loading_storage_paths_relative_defaults() -> None:
             }
         }
     }
-    config_root = Path("/tmp/spine_cfg")
-    loader._resolve_local_loading_storage_paths(cfg, config_root)
+    project_root = Path("/tmp/myproject")
+    loader._resolve_local_loading_storage_paths(cfg, layout_root=project_root)
     assert cfg["defaults"]["loading"]["storage_root"] == str(
-        (config_root / ".spine/local-output").resolve()
+        (project_root / ".spine/local-output").resolve()
     )
 
 
@@ -34,14 +34,14 @@ def test_resolve_local_loading_storage_paths_absolute_unchanged() -> None:
             }
         }
     }
-    loader._resolve_local_loading_storage_paths(cfg, Path("/tmp/any"))
+    loader._resolve_local_loading_storage_paths(cfg, layout_root=Path("/tmp/any"))
     assert cfg["defaults"]["loading"]["storage_root"] == "/var/data"
 
 
 def test_resolve_local_loading_storage_paths_skips_s3() -> None:
     loader = ConfigLoader()
     cfg = {"defaults": {"loading": {"destination": "s3", "storage_root": "rel", "prefix": "a/b"}}}
-    loader._resolve_local_loading_storage_paths(cfg, Path("/tmp/c"))
+    loader._resolve_local_loading_storage_paths(cfg, layout_root=Path("/tmp/c"))
     assert cfg["defaults"]["loading"]["storage_root"] == "rel"
 
 
@@ -66,9 +66,10 @@ def test_resolve_local_loading_storage_paths_resource(tmp_path: Path) -> None:
             }
         },
     }
-    root = tmp_path / "cfgdir"
-    root.mkdir()
-    loader._resolve_local_loading_storage_paths(cfg, root.resolve())
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "config").mkdir()
+    loader._resolve_local_loading_storage_paths(cfg, layout_root=repo.resolve())
     assert cfg["sources"]["api"]["resources"]["r1"]["loading"]["storage_root"] == str(
-        (root / "out/data").resolve()
+        (repo / "out/data").resolve()
     )

--- a/tests/test_config/test_defaults_config_loading.py
+++ b/tests/test_config/test_defaults_config_loading.py
@@ -1,0 +1,27 @@
+"""Tests for DefaultsConfig.loading built-in default."""
+
+from src.config.config_models import DefaultsConfig, LoadingConfig
+
+
+def test_defaults_config_loading_factory_is_local_delta() -> None:
+    d = DefaultsConfig()
+    assert d.loading.destination == "local"
+    assert d.loading.format == "delta"
+    assert d.loading.write_mode == "overwrite"
+    assert d.loading.compression == "snappy"
+    assert d.loading.storage_root == ".spine/local-output"
+    assert d.loading.prefix == "default/output"
+    assert d.loading.bucket is None
+
+
+def test_defaults_config_explicit_loading_overrides() -> None:
+    d = DefaultsConfig(
+        loading=LoadingConfig(
+            destination="s3",
+            bucket="b",
+            prefix="src/res",
+            format="delta",
+        )
+    )
+    assert d.loading.destination == "s3"
+    assert d.loading.bucket == "b"

--- a/tests/test_config/test_loading_config.py
+++ b/tests/test_config/test_loading_config.py
@@ -1,0 +1,69 @@
+"""Tests for LoadingConfig (S3 and local destinations)."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.config_models import LoadingConfig
+
+
+def test_loading_config_s3_valid() -> None:
+    cfg = LoadingConfig(
+        destination="s3",
+        bucket="b",
+        prefix="src/res",
+        format="delta",
+    )
+    assert cfg.bucket == "b"
+    assert cfg.prefix == "src/res"
+
+
+def test_loading_config_s3_requires_bucket() -> None:
+    with pytest.raises(ValidationError) as ei:
+        LoadingConfig(destination="s3", prefix="a/b", format="delta")
+    assert "bucket" in str(ei.value).lower()
+
+
+def test_loading_config_s3_requires_prefix_shape() -> None:
+    with pytest.raises(ValidationError) as ei:
+        LoadingConfig(destination="s3", bucket="b", prefix="onlyone", format="delta")
+    assert "prefix" in str(ei.value).lower() or "source_name" in str(ei.value).lower()
+
+
+def test_loading_config_local_valid(tmp_path: Path) -> None:
+    cfg = LoadingConfig(
+        destination="local",
+        storage_root=str(tmp_path.resolve()),
+        prefix="src/res",
+        format="delta",
+    )
+    assert cfg.storage_root == str(tmp_path.resolve())
+
+
+def test_loading_config_local_requires_storage_root() -> None:
+    with pytest.raises(ValidationError) as ei:
+        LoadingConfig(destination="local", prefix="a/b", format="delta")
+    assert "storage_root" in str(ei.value).lower()
+
+
+def test_loading_config_local_allows_relative_storage_root() -> None:
+    """Relative paths are allowed on the model; ConfigLoader resolves against CONFIG_PATH."""
+    cfg = LoadingConfig(
+        destination="local",
+        storage_root=".spine/local-output",
+        prefix="a/b",
+        format="delta",
+    )
+    assert cfg.storage_root == ".spine/local-output"
+
+
+def test_loading_config_merge_requires_keys() -> None:
+    with pytest.raises(ValidationError):
+        LoadingConfig(
+            destination="local",
+            storage_root="/tmp",
+            prefix="a/b",
+            format="delta",
+            write_mode="merge",
+        )

--- a/tests/test_config/test_loading_config.py
+++ b/tests/test_config/test_loading_config.py
@@ -48,7 +48,7 @@ def test_loading_config_local_requires_storage_root() -> None:
 
 
 def test_loading_config_local_allows_relative_storage_root() -> None:
-    """Relative paths are allowed on the model; ConfigLoader resolves against CONFIG_PATH."""
+    """Relative paths are allowed on the model; ConfigLoader resolves against repository root."""
     cfg = LoadingConfig(
         destination="local",
         storage_root=".spine/local-output",

--- a/tests/test_loader/test_local_storage.py
+++ b/tests/test_loader/test_local_storage.py
@@ -1,0 +1,36 @@
+"""Tests for local storage path checks."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.loader.local_storage import check_local_storage_root
+from src.utils.exceptions import HandlerError
+
+
+def test_check_local_storage_root_ok(tmp_path: Path) -> None:
+    d = tmp_path / "w"
+    d.mkdir()
+    check_local_storage_root(d)
+
+
+def test_check_local_storage_root_not_dir(tmp_path: Path) -> None:
+    f = tmp_path / "file"
+    f.write_text("x")
+    with pytest.raises(HandlerError, match="not a directory"):
+        check_local_storage_root(f)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="directory mode bits differ on Windows")
+@pytest.mark.skipif(getattr(os, "getuid", lambda: -1)() == 0, reason="root may write to any path")
+def test_check_local_storage_root_not_writable(tmp_path: Path) -> None:
+    d = tmp_path / "ro"
+    d.mkdir()
+    os.chmod(d, 0o555)
+    try:
+        with pytest.raises(HandlerError, match="not writable"):
+            check_local_storage_root(d)
+    finally:
+        os.chmod(d, 0o755)

--- a/tests/test_loader/test_object_store.py
+++ b/tests/test_loader/test_object_store.py
@@ -1,0 +1,139 @@
+"""Tests for loader object store and loading_base_uri."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.loader.object_store import SparkFilesystemObjectStore, loading_base_uri
+from src.utils.exceptions import LoaderError
+
+
+def test_loading_base_uri_s3() -> None:
+    assert loading_base_uri(destination="s3", bucket="my-bucket") == "s3a://my-bucket"
+
+
+def test_loading_base_uri_s3_strips_whitespace() -> None:
+    assert loading_base_uri(destination="s3", bucket="  my-bucket  ") == "s3a://my-bucket"
+
+
+def test_loading_base_uri_s3_missing_bucket() -> None:
+    with pytest.raises(ValueError, match="bucket is required"):
+        loading_base_uri(destination="s3", bucket=None)
+
+
+def test_loading_base_uri_local(tmp_path: Path) -> None:
+    root = tmp_path / "out"
+    root.mkdir()
+    uri = loading_base_uri(destination="local", storage_root=str(root))
+    assert uri == root.resolve().as_uri().rstrip("/")
+
+
+def test_loading_base_uri_local_missing_root() -> None:
+    with pytest.raises(ValueError, match="storage_root is required"):
+        loading_base_uri(destination="local", storage_root=None)
+
+
+def test_loading_base_uri_unknown_destination() -> None:
+    with pytest.raises(ValueError, match="Unsupported"):
+        loading_base_uri(destination="azure", bucket="x")
+
+
+@pytest.fixture
+def mocked_spark() -> MagicMock:
+    spark = MagicMock()
+    spark.sparkContext._jsc.hadoopConfiguration.return_value = MagicMock(name="hadoop_conf")
+    spark.sparkContext._jvm = MagicMock(name="jvm")
+    return spark
+
+
+def test_resolve_path_joins_and_trailing_slash(mocked_spark: MagicMock) -> None:
+    store = SparkFilesystemObjectStore(mocked_spark)
+    assert store.resolve_path("s3a://b", "p", "q") == "s3a://b/p/q"
+    assert store.resolve_path("s3a://b/", "p/", "/q/") == "s3a://b/p/q"
+    assert store.resolve_path("file:///tmp", trailing_slash=True) == "file:///tmp/"
+
+
+def test_exists(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    fs.exists.return_value = True
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+    path_obj = MagicMock()
+    jvm.org.apache.hadoop.fs.Path.return_value = path_obj
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    assert store.exists("s3a://b/path") is True
+    jvm.org.apache.hadoop.fs.Path.assert_called_once()
+    fs.exists.assert_called_once_with(path_obj)
+
+
+def test_delete_when_present(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    fs.exists.return_value = True
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+    path_obj = MagicMock()
+    jvm.org.apache.hadoop.fs.Path.return_value = path_obj
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    store.delete("s3a://b/tmp", recursive=True)
+    fs.delete.assert_called_once_with(path_obj, True)
+
+
+def test_move_success(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    fs.rename.return_value = True
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+    src = MagicMock()
+    dst = MagicMock()
+    jvm.org.apache.hadoop.fs.Path.side_effect = [src, dst]
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    store.move("s3a://b/a", "s3a://b/b")
+    fs.rename.assert_called_once_with(src, dst)
+
+
+def test_move_failure_raises_loader_error(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    fs.rename.return_value = False
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+    jvm.org.apache.hadoop.fs.Path.side_effect = [MagicMock(), MagicMock()]
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    with pytest.raises(LoaderError, match="Failed to move"):
+        store.move("s3a://b/a", "s3a://b/b")
+
+
+def test_glob_first_part_file(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    status = MagicMock()
+    status.getPath.return_value.toString.return_value = "s3a://b/out/part-00000"
+    fs.globStatus.return_value = [status]
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    assert store.glob_first_part_file("s3a://b/out") == "s3a://b/out/part-00000"
+
+
+def test_glob_first_part_file_empty(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    fs.globStatus.return_value = []
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    assert store.glob_first_part_file("s3a://b/out") is None
+
+
+def test_is_empty_directory(mocked_spark: MagicMock) -> None:
+    jvm = mocked_spark.sparkContext._jvm
+    fs = MagicMock()
+    fs.exists.return_value = False
+    jvm.org.apache.hadoop.fs.FileSystem.get.return_value = fs
+
+    store = SparkFilesystemObjectStore(mocked_spark)
+    assert store.is_empty_directory("s3a://b/missing") is True


### PR DESCRIPTION
## Summary

Adds **`destination: local`** (Delta under `file://`) with **`storage_root`** / **`prefix`**, a small **`object_store`** layer under `src/loader/` (S3 loader refactored to use it), a new loading option for local storage, and **`repository_root()`** so relative **`storage_root`** resolves under the **directory that contains `src/`**.

**Operators:** if config is mounted outside the repo but output should live there, use an **absolute** `storage_root`.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

Fixes #14 .
