### PR TITLE
fix: align settings config approach to pydantic v2 

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -37,18 +37,19 @@ def _resolve_pipeline_config_dir(config_path_setting: str) -> Path:
 class SparkSettings(BaseSettings):
     """Spark-specific settings."""
 
+    model_config = SettingsConfigDict(extra="ignore")
+
     APP_NAME: str = "DataIngestion"
     MASTER: str = "local[*]"
     DRIVER_MEMORY: str = "4g"
     MEMORY_FRACTION: float = 0.8
     MEMORY_STORAGE_FRACTION: float = 0.3
 
-    class Config:
-        extra = "ignore"
-
 
 class APISettings(BaseSettings):
     """API-specific settings."""
+
+    model_config = SettingsConfigDict(extra="ignore")
 
     TIMEOUT: int = Field(default=30, description="Request timeout in seconds")
 
@@ -71,12 +72,11 @@ class APISettings(BaseSettings):
             self.INITIAL_DELAY = config.defaults.retry.initial_delay
             self.RETRY_BACKOFF = config.defaults.retry.backoff_factor
 
-    class Config:
-        extra = "ignore"
-
 
 class AWSSettings(BaseSettings):
     """AWS-specific settings."""
+
+    model_config = SettingsConfigDict(extra="ignore")
 
     REGION: str = Field(default="ap-southeast-2", description="AWS region")
 
@@ -91,9 +91,6 @@ class AWSSettings(BaseSettings):
         except AWSError as e:
             logger.error("Failed to initialize AWS settings", extra_fields={"error": str(e)})
             raise
-
-    class Config:
-        extra = "ignore"
 
 
 class DatabricksSettings(BaseSettings):


### PR DESCRIPTION
## Summary

I noticed that databricks had slightly different settings approach than AWS, Spark. 
This PR aligns the Settings to use the Databricks class approach which is correct for Pydantic v2 which is the version we use. 

This seems to be the recommended style:

<img width="720" height="211" alt="image" src="https://github.com/user-attachments/assets/2ec2da5c-ea99-4e92-ae95-d3ab53746a84" />

https://pydantic.dev/docs/validation/latest/concepts/pydantic_settings/

And the style the code moves away from appears to be deprecated: 

<img width="942" height="165" alt="image" src="https://github.com/user-attachments/assets/e30072d5-a243-42e8-b07e-2ebac0169f7a" />

https://pydantic.dev/docs/validation/latest/get-started/migration/

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

