### PR TITLE
feat: extended backfill visibility to body, path and query parameters

### DIFF
--- a/docs/configuration/backfill.md
+++ b/docs/configuration/backfill.md
@@ -1,6 +1,6 @@
 # Backfill Configuration
 
-Date-range backfill splits historical data fetching into multiple API requests with fixed-size date windows. Configure backfill under **request_inputs** for body inputs: use a `value` that is a dict containing a **backfill** key (e.g. `request_inputs.startDate.value.backfill`).
+Date-range backfill splits historical data fetching into multiple API requests with fixed-size date windows. Configure backfill under **request_inputs** on **path**, **query**, or **body** inputs (same rules as normal inputs: GET defaults to query, POST defaults to body unless you set `location`). Use a `value` that is a dict containing a **backfill** key (e.g. `request_inputs.startDate.value.backfill`).
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@ Backfill can run in two ways:
 
 ## Configuration Shape
 
-Backfill requires exactly two body request inputs (in `request_inputs`) whose `value` contains a **backfill** key:
+Backfill requires exactly two request inputs (in `request_inputs`, any of path / query / body) whose `value` contains a **backfill** key:
 
 - **Driver (STATIC_DATE)**: Defines the sequence of window starts. Requires `start`, `end`, and `increment`. Supports static YYYY-MM-DD strings or dynamic values (e.g. `type: DATE`, `operation: TODAY`).
 
@@ -63,7 +63,7 @@ This caps the last window's `endDate` at the latest date the API supports.
 
 ## Example
 
-Minimal backfill config (body request inputs with `value` containing `backfill`):
+Minimal backfill config (POST body example; `value` contains `backfill`):
 
 ```yaml
 request_inputs:
@@ -89,4 +89,4 @@ exclude_from_request_body:
   - endDate
 ```
 
-This produces 15-day windows from 2026-01-01 up to 2 days ago. List backfill driver/reference keys in **exclude_from_request_body** so they are not sent in the API body.
+This produces 15-day windows from 2026-01-01 up to 2 days ago. For **body** inputs, list backfill driver/reference keys in **exclude_from_request_body** when those keys must not appear in the JSON body (they still drive date windows and request context). Query and path parameters are sent as usual for each backfill window.

--- a/docs/configuration/backfill.md
+++ b/docs/configuration/backfill.md
@@ -27,6 +27,8 @@ Backfill requires exactly two request inputs (in `request_inputs`, any of path /
 
 - **Reference (REFERENCE)**: Defines the window end for each start. References the driver field, adds `increment`, and caps at `limit`. Requires `field`, `increment`, and `limit`.
 
+Only **one** such pair is allowed per resource. You may place the driver on one location (e.g. query) and the reference on another (e.g. body); that still drives **one** sequence of windows per request batch, not two independent backfills or a Cartesian product. If the merged `request_inputs` contain more than one valid `STATIC_DATE` driver or more than one valid `REFERENCE`, plan build fails with a clear error.
+
 ## Date Pair Generation
 
 Each window spans at most `ref_increment` days. `endDate` is always the **last day included** in the window (inclusive semantics). The last window may be shorter when capped at `limit`.

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -68,7 +68,7 @@ sources:
 | Topic | Description |
 |-------|-------------|
 | [Request inputs](parameters.md) | Request inputs (path/query/body), static/dynamic, SOURCE, DATABRICKS, DATE, batching, formats, shorthand, headers, POST body |
-| [Backfill](backfill.md) | Date-range backfill for body request inputs |
+| [Backfill](backfill.md) | Date-range backfill for path, query, or body request inputs |
 | [Loading](loading.md) | Delta save modes (overwrite, append, merge), S3, local |
 | [Auth](auth.md) | OAuth JWT, bearer token, API key |
 | [Transformations](transformations.md) | add_column, add_column_from_request, ensure_param_values_in_output |

--- a/docs/configuration/value-resolution.md
+++ b/docs/configuration/value-resolution.md
@@ -97,7 +97,7 @@ request_inputs:
 
 ## Backfill Config
 
-Backfill for body inputs uses a `value` dict with a `backfill` key. Jinja can be used for dynamic `end` and `limit`:
+Backfill for path, query, or body inputs uses a `value` dict with a `backfill` key. Jinja can be used for dynamic `end` and `limit`:
 
 ```yaml
 request_inputs:

--- a/src/config/backfill_config.py
+++ b/src/config/backfill_config.py
@@ -4,7 +4,10 @@ Backfill configuration parsing for date-range backfill.
 Backfill is detected from request inputs (path, query, or body) whose ``value`` is a
 dict containing ``backfill``. Callers pass a flat name -> ``value`` map (e.g. from
 ``ResourceConfig.get_request_input_values_for_backfill()``).
-Supports STATIC_DATE (driver) and REFERENCE (tied to driver) types.
+
+Each resource supports a single driver/reference pair: one ``STATIC_DATE`` and one
+``REFERENCE``. Extra valid blocks raise ``ValueError`` (wrapped as ``PlanningError``
+during plan build).
 """
 
 from dataclasses import dataclass
@@ -89,13 +92,15 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
     """
     Detect and parse backfill configuration from resource request input values.
 
-    Looks for one driver field (backfill.type: STATIC_DATE) and one reference
-    field (backfill.type: REFERENCE, field: <driver_key>). Returns None if
-    backfill is not configured or config is invalid.
+    Each resource supports **at most one** date-range backfill: one ``STATIC_DATE``
+    driver and one ``REFERENCE`` tied to that driver. The driver and reference may
+    live on different ``request_inputs`` locations (path, query, body); that still
+    produces a single stream of date windows, not a Cartesian product of multiple
+    backfills.
 
-    Args:
-        input_values: Map of request input name to configured ``value`` (path,
-            query, or body), each optionally shaped as ``{ value: ..., backfill: ... }``.
+    Raises:
+        ValueError: If more than one valid driver or more than one valid reference
+            is present (duplicate ``backfill`` blocks).
 
     Returns:
         BackfillConfig if valid backfill is configured, else None.
@@ -116,9 +121,6 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
             continue
         bf_type = (backfill.get("type") or "").strip().upper()
         if bf_type == BACKFILL_TYPE_STATIC_DATE:
-            if driver_key is not None:
-                # Only one driver supported
-                continue
             start = backfill.get("start")
             end = backfill.get("end")
             increment = backfill.get("increment")
@@ -126,15 +128,23 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
                 continue
             inclusive = backfill.get("inclusive", False)
             try:
-                driver_config = BackfillStaticDateConfig(
+                candidate_driver = BackfillStaticDateConfig(
                     start=start,
                     end=end,
                     increment=str(increment).strip(),
                     inclusive=bool(inclusive),
                 )
-                parse_increment(driver_config.increment)
+                parse_increment(candidate_driver.increment)
             except (ValueError, TypeError):
                 continue
+            if driver_key is not None:
+                raise ValueError(
+                    "Backfill allows at most one STATIC_DATE driver per resource; "
+                    f"found another on input {key!r} (first driver: {driver_key!r}). "
+                    "Splitting start/end across path, query, or body is fine; defining "
+                    "two independent driver blocks is not."
+                )
+            driver_config = candidate_driver
             driver_key = key
         elif bf_type == BACKFILL_TYPE_REFERENCE:
             ref_field = backfill.get("field")
@@ -143,14 +153,21 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
             if not ref_field or not ref_increment or limit is None:
                 continue
             try:
-                reference_config = BackfillReferenceConfig(
+                candidate_reference = BackfillReferenceConfig(
                     field=str(ref_field).strip(),
                     increment=str(ref_increment).strip(),
                     limit=limit,
                 )
-                parse_increment(reference_config.increment)
+                parse_increment(candidate_reference.increment)
             except (ValueError, TypeError):
                 continue
+            if reference_key is not None:
+                raise ValueError(
+                    "Backfill allows at most one REFERENCE field per resource; "
+                    f"found another on input {key!r} (first reference: {reference_key!r}). "
+                    "Use exactly one driver/reference pair."
+                )
+            reference_config = candidate_reference
             reference_key = key
 
     if (

--- a/src/config/backfill_config.py
+++ b/src/config/backfill_config.py
@@ -1,8 +1,9 @@
 """
 Backfill configuration parsing for date-range backfill.
 
-Backfill is detected from body inputs whose value is a dict containing "backfill".
-Callers pass a body-like dict (e.g. from request_inputs with location=body, key -> config.value).
+Backfill is detected from request inputs (path, query, or body) whose ``value`` is a
+dict containing ``backfill``. Callers pass a flat name -> ``value`` map (e.g. from
+``ResourceConfig.get_request_input_values_for_backfill()``).
 Supports STATIC_DATE (driver) and REFERENCE (tied to driver) types.
 """
 
@@ -31,7 +32,7 @@ class BackfillStaticDateConfig:
 class BackfillReferenceConfig:
     """Reference backfill: value = driver_field + increment, capped at limit."""
 
-    field: str  # request_body key this references (e.g. startDate)
+    field: str  # request input name of the driver (e.g. startDate)
     increment: str  # e.g. '15 DAY'
     limit: Any  # str or dict for dynamic (e.g. type: DATE, operation: TODAY)
 
@@ -40,11 +41,11 @@ class BackfillReferenceConfig:
 class BackfillConfig:
     """Parsed backfill configuration for a resource."""
 
-    driver_key: str  # request_body key that drives the ranges (e.g. startDate)
-    reference_key: str  # request_body key tied to driver (e.g. endDate)
+    driver_key: str  # request input name that drives the ranges (e.g. startDate)
+    reference_key: str  # request input name tied to driver (e.g. endDate)
     driver_config: BackfillStaticDateConfig
     reference_config: BackfillReferenceConfig
-    request_body_keys: List[str]  # [driver_key, reference_key] for injection
+    field_keys: List[str]  # [driver_key, reference_key]; injected into request context
 
 
 def parse_increment(increment_str: str) -> relativedelta:
@@ -84,21 +85,22 @@ def parse_increment(increment_str: str) -> relativedelta:
     raise ValueError(f"increment unit must be DAY, WEEK, or MONTH, got: {unit!r}")
 
 
-def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[BackfillConfig]:
+def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[BackfillConfig]:
     """
-    Detect and parse backfill configuration from resource request body inputs.
+    Detect and parse backfill configuration from resource request input values.
 
     Looks for one driver field (backfill.type: STATIC_DATE) and one reference
     field (backfill.type: REFERENCE, field: <driver_key>). Returns None if
     backfill is not configured or config is invalid.
 
     Args:
-        request_body: Resource body-input dict (may contain nested backfill).
+        input_values: Map of request input name to configured ``value`` (path,
+            query, or body), each optionally shaped as ``{ value: ..., backfill: ... }``.
 
     Returns:
         BackfillConfig if valid backfill is configured, else None.
     """
-    if not request_body or not isinstance(request_body, dict):
+    if not input_values or not isinstance(input_values, dict):
         return None
 
     driver_key: Optional[str] = None
@@ -106,7 +108,7 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
     reference_key: Optional[str] = None
     reference_config: Optional[BackfillReferenceConfig] = None
 
-    for key, value in request_body.items():
+    for key, value in input_values.items():
         if not isinstance(value, dict) or "backfill" not in value:
             continue
         backfill = value.get("backfill")
@@ -166,5 +168,5 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
         reference_key=reference_key,
         driver_config=driver_config,
         reference_config=reference_config,
-        request_body_keys=[driver_key, reference_key],
+        field_keys=[driver_key, reference_key],
     )

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -912,6 +912,22 @@ class ResourceConfig(BaseModel):
             if config.location == location
         }
 
+    def get_request_input_values_for_backfill(self) -> Dict[str, Any]:
+        """
+        Flat map of input name to configured ``value`` for backfill detection.
+
+        Merges path, then query, then body inputs. Input names are unique per
+        resource, so order only matters if that invariant were violated.
+
+        Returns:
+            Empty dict when there are no request_inputs.
+        """
+        merged: Dict[str, Any] = {}
+        for loc in ("path", "query", "body"):
+            for name, cfg in self.get_inputs_by_location(loc).items():
+                merged[name] = cfg.value
+        return merged
+
     def get_batch_inputs(self) -> Dict[str, RequestInputConfig]:
         """
         Get request inputs that require batching (any location).

--- a/src/planner/execution_plan.py
+++ b/src/planner/execution_plan.py
@@ -563,7 +563,14 @@ class ExecutionPlan:
 
                 # Backfill: value may be a dict with "backfill" on path, query, or body inputs
                 inputs_for_backfill = resource.get_request_input_values_for_backfill()
-                backfill_cfg = get_backfill_config(inputs_for_backfill or None)
+                try:
+                    backfill_cfg = get_backfill_config(inputs_for_backfill or None)
+                except ValueError as e:
+                    raise PlanningError(
+                        message="Invalid backfill configuration",
+                        operation="_build_resource_metadata",
+                        details={"resource": resource_id, "error": str(e)},
+                    ) from e
                 self._resource_metadata[resource_id] = ResourceMetadata(
                     source_name=source_name,
                     resource_name=resource_name,

--- a/src/planner/execution_plan.py
+++ b/src/planner/execution_plan.py
@@ -48,7 +48,7 @@ class ResourceMetadata:
     parent_fields: Set[str] = None  # Fields that need to be carried from parent context
     config: ResourceConfig = None  # Reference to the resource configuration
     backfill_config: Optional[BackfillConfig] = (
-        None  # Request-body date-range backfill, if configured
+        None  # Request-input date-range backfill (path/query/body), if configured
     )
 
     def estimate_request_count(self) -> Optional[int]:
@@ -561,10 +561,9 @@ class ExecutionPlan:
                         if source_config.field:
                             parent_fields.add(source_config.field)
 
-                # Backfill from body inputs: value may be a dict with "backfill" key
-                body_inputs = resource.get_inputs_by_location("body")
-                body_dict = {n: c.value for n, c in body_inputs.items()} if body_inputs else None
-                backfill_cfg = get_backfill_config(body_dict)
+                # Backfill: value may be a dict with "backfill" on path, query, or body inputs
+                inputs_for_backfill = resource.get_request_input_values_for_backfill()
+                backfill_cfg = get_backfill_config(inputs_for_backfill or None)
                 self._resource_metadata[resource_id] = ResourceMetadata(
                     source_name=source_name,
                     resource_name=resource_name,

--- a/src/utils/dynamic_values.py
+++ b/src/utils/dynamic_values.py
@@ -384,7 +384,7 @@ class DynamicValueResolver:
 
         # Handle dictionary format for complex values
         if isinstance(value, dict) and not isinstance(value, (DynamicValue, ComplexDynamicValue)):
-            # Handle flat DATE format (type, operation, days at top level) - used by request_body backfill
+            # Handle flat DATE format (type, operation, days at top level) - used by backfill limits
             if "type" in value:
                 try:
                     dynamic_type = DynamicValueType(value["type"].upper())

--- a/tests/test_config/test_backfill_config.py
+++ b/tests/test_config/test_backfill_config.py
@@ -1,0 +1,140 @@
+"""Tests for backfill config detection from request input values."""
+
+from src.config.backfill_config import get_backfill_config
+from src.config.config_models import ResourceConfig
+
+
+def test_get_backfill_config_query_style_flat_dict() -> None:
+    """GET-style query parameters (snake_case) with nested value + backfill."""
+    input_values = {
+        "start_date": {
+            "value": "{{ date('PREVIOUS_SUNDAY') }}",
+            "backfill": {
+                "type": "STATIC_DATE",
+                "start": "2021-01-03",
+                "end": "2026-04-21",
+                "inclusive": False,
+                "increment": "1 WEEK",
+            },
+        },
+        "end_date": {
+            "value": "{{ date('PREVIOUS_SATURDAY') }}",
+            "backfill": {
+                "type": "REFERENCE",
+                "field": "start_date",
+                "increment": "7 DAY",
+                "limit": "2026-04-14",
+            },
+        },
+    }
+    cfg = get_backfill_config(input_values)
+    assert cfg is not None
+    assert cfg.driver_key == "start_date"
+    assert cfg.reference_key == "end_date"
+    assert cfg.reference_config.field == "start_date"
+    assert cfg.field_keys == ["start_date", "end_date"]
+
+
+def test_get_backfill_config_body_style_flat_dict() -> None:
+    """POST body camelCase keys (doc example shape)."""
+    input_values = {
+        "startDate": {
+            "value": "{{ date('DAYS_AGO', days=9) }}",
+            "backfill": {
+                "type": "STATIC_DATE",
+                "start": "2026-01-01",
+                "end": "2026-04-21",
+                "inclusive": False,
+                "increment": "15 DAY",
+            },
+        },
+        "endDate": {
+            "value": "{{ date('DAYS_AGO', days=2) }}",
+            "backfill": {
+                "type": "REFERENCE",
+                "field": "startDate",
+                "increment": "15 DAY",
+                "limit": "2026-04-14",
+            },
+        },
+    }
+    cfg = get_backfill_config(input_values)
+    assert cfg is not None
+    assert cfg.driver_key == "startDate"
+    assert cfg.reference_key == "endDate"
+
+
+def test_get_backfill_config_mixed_query_without_backfill_and_body_backfill() -> None:
+    """Non-backfill query keys must not prevent detecting body backfill."""
+    input_values = {
+        "advertiser_id": {"type": "SOURCE"},
+        "startDate": {
+            "value": "x",
+            "backfill": {
+                "type": "STATIC_DATE",
+                "start": "2026-01-01",
+                "end": "2026-01-31",
+                "increment": "15 DAY",
+            },
+        },
+        "endDate": {
+            "value": "y",
+            "backfill": {
+                "type": "REFERENCE",
+                "field": "startDate",
+                "increment": "15 DAY",
+                "limit": "2026-01-31",
+            },
+        },
+    }
+    cfg = get_backfill_config(input_values)
+    assert cfg is not None
+    assert cfg.driver_key == "startDate"
+
+
+def test_get_request_input_values_for_backfill_merges_path_query_body() -> None:
+    """ResourceConfig merges locations in path → query → body order."""
+    # Use dict-shaped inputs (as YAML does); passing RequestInputConfig instances as
+    # top-level values is incorrect because normalize_request_inputs wraps non-dicts.
+    resource = ResourceConfig(
+        method="GET",
+        path="/accounts/{account_id}/reports",
+        request_inputs={
+            "account_id": {"value": "123456", "location": "path"},
+            "start_date": {
+                "value": {
+                    "value": "{{ date('PREVIOUS_SUNDAY') }}",
+                    "backfill": {
+                        "type": "STATIC_DATE",
+                        "start": "2021-01-03",
+                        "end": "2026-04-21",
+                        "inclusive": False,
+                        "increment": "1 WEEK",
+                    },
+                },
+                "location": "query",
+            },
+            "end_date": {
+                "value": {
+                    "value": "{{ date('PREVIOUS_SATURDAY') }}",
+                    "backfill": {
+                        "type": "REFERENCE",
+                        "field": "start_date",
+                        "increment": "7 DAY",
+                        "limit": "2026-04-14",
+                    },
+                },
+                "location": "query",
+            },
+        },
+    )
+    merged = resource.get_request_input_values_for_backfill()
+    assert set(merged.keys()) == {"account_id", "start_date", "end_date"}
+    cfg = get_backfill_config(merged)
+    assert cfg is not None
+    assert cfg.driver_key == "start_date"
+
+
+def test_get_backfill_config_empty_returns_none() -> None:
+    assert get_backfill_config({}) is None
+    assert get_backfill_config(None) is None

--- a/tests/test_config/test_backfill_config.py
+++ b/tests/test_config/test_backfill_config.py
@@ -1,5 +1,7 @@
 """Tests for backfill config detection from request input values."""
 
+import pytest
+
 from src.config.backfill_config import get_backfill_config
 from src.config.config_models import ResourceConfig
 
@@ -138,3 +140,64 @@ def test_get_request_input_values_for_backfill_merges_path_query_body() -> None:
 def test_get_backfill_config_empty_returns_none() -> None:
     assert get_backfill_config({}) is None
     assert get_backfill_config(None) is None
+
+
+def _valid_static_backfill(start: str = "2026-01-01") -> dict:
+    return {
+        "type": "STATIC_DATE",
+        "start": start,
+        "end": "2026-01-31",
+        "increment": "15 DAY",
+    }
+
+
+def _valid_reference(field: str = "start_date") -> dict:
+    return {
+        "type": "REFERENCE",
+        "field": field,
+        "increment": "15 DAY",
+        "limit": "2026-01-31",
+    }
+
+
+def test_get_backfill_config_rejects_second_static_date_driver() -> None:
+    with pytest.raises(ValueError, match="at most one STATIC_DATE"):
+        get_backfill_config(
+            {
+                "start_date": {"value": "a", "backfill": _valid_static_backfill("2026-01-01")},
+                "other_start": {"value": "b", "backfill": _valid_static_backfill("2026-02-01")},
+                "end_date": {"value": "c", "backfill": _valid_reference("start_date")},
+            }
+        )
+
+
+def test_get_backfill_config_rejects_second_reference() -> None:
+    with pytest.raises(ValueError, match="at most one REFERENCE"):
+        get_backfill_config(
+            {
+                "start_date": {"value": "a", "backfill": _valid_static_backfill()},
+                "end_date": {"value": "b", "backfill": _valid_reference("start_date")},
+                "alt_end": {"value": "c", "backfill": _valid_reference("start_date")},
+            }
+        )
+
+
+def test_get_backfill_config_allows_invalid_second_static_without_raise() -> None:
+    """A second STATIC_DATE block that fails validation is ignored (not a duplicate driver)."""
+    cfg = get_backfill_config(
+        {
+            "start_date": {"value": "a", "backfill": _valid_static_backfill()},
+            "broken": {
+                "value": "b",
+                "backfill": {
+                    "type": "STATIC_DATE",
+                    "start": "2026-01-01",
+                    "end": "2026-01-31",
+                    "increment": "not-a-valid-increment",
+                },
+            },
+            "end_date": {"value": "c", "backfill": _valid_reference("start_date")},
+        }
+    )
+    assert cfg is not None
+    assert cfg.driver_key == "start_date"

--- a/tests/test_utils/test_backfill_dates.py
+++ b/tests/test_utils/test_backfill_dates.py
@@ -35,7 +35,7 @@ def _make_config(inclusive: bool, limit_str: str) -> BackfillConfig:
         reference_key="endDate",
         driver_config=driver,
         reference_config=reference,
-        request_body_keys=["startDate", "endDate"],
+        field_keys=["startDate", "endDate"],
     )
 
 


### PR DESCRIPTION
## Summary

**Problem**  
Backfill was only parsed from body `request_inputs` at plan build time. GET resources default date fields to **query**, so `backfill_config` was never set, auto-backfill did not run when destinations were empty, and historical windows were not expanded even though the handler already applies backfill dates from context for all locations.

**Change**  
- Merge path, query, and body input values via `ResourceConfig.get_request_input_values_for_backfill()` and pass that map into `get_backfill_config()`.  
- Rename `get_backfill_config` argument to `input_values`; on `BackfillConfig`, replace the unused `request_body_keys` / `backfill_field_keys` attribute with **`field_keys`** (`[driver_key, reference_key]`).  

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
