### PR TITLE
Main sync: HANA Spark JDBC reads, backfill inputs, and settings/docs alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,15 @@ When work is tracked in a GitHub issue, treat the issue body as the contract.
 
 - **Before coding** — Read **Problem statement**, **Scope** / **Out of scope**, and **Done when**. Stay inside that boundary. If the issue is wrong, incomplete, or you need a wider change, **suggest** comment text for the operator to post on the issue (or propose splitting a follow-up issue) instead of folding extra requirements into one PR.
 - **Traceability** — Assistants should **not** open or edit pull requests or issues on GitHub via MCP/API unless the operator explicitly asks for that. Default: propose a **Related** line (and the rest of the PR description) the operator can paste when they open the PR, following [`.github/pull_request_template.md`](.github/pull_request_template.md): e.g. `Fixes #N` if merge should close the issue, or `Refs #N` for partial or exploratory work.
+- **Comments and other mutating actions** — Do **not** post issue or pull request **comments**, labels, assignments, or other GitHub mutations via MCP/API unless the operator **explicitly confirms** that you should do so in that conversation. Default to **drafting** comment text in the chat for them to copy.
 - **Operator-visible changes** — If the issue changes YAML shape, defaults, or runtime behavior operators rely on, remind them to update `docs/configuration/` (and examples under `config/` where applicable) in the same change set, not as a silent follow-up.
+
+### Issue-related questions (triage and overlap)
+
+When the task is to check existing issues, relate work to an issue, or avoid duplicating tickets:
+
+- **Prefer the GitHub MCP** when it is enabled for the workspace: use read-only tools (`list_issues`, `search_issues`, `issue_read`, and so on) rather than guessing from memory. Discover the correct MCP server identifier and tool parameters from the project’s MCP descriptor files.
+- **Gather full context** — The issue body alone is not enough. Also pull **comments**, **labels**, and **sub-issues** when the API exposes them, and scan for cross-links in the description (`Depends on`, `Refs`, duplicate pointers). Summarize overlap with the current task using that complete picture.
+- **Read-only vs write** — Using MCP to **read** issues and comments is encouraged for accuracy; creating, editing, or commenting still requires explicit operator consent per **Traceability** and **Comments and other mutating actions** above.
 
 For filing issues, use [`.github/ISSUE_DRAFT_STANDARD.md`](.github/ISSUE_DRAFT_STANDARD.md) and the **Engineering task** template under [`.github/ISSUE_TEMPLATE/engineering_task.md`](.github/ISSUE_TEMPLATE/engineering_task.md) so scope and acceptance criteria stay consistent with how implementers work.

--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ config/              # defaults.yml, sources/, queries/ (operator-local; templat
 src/
 ├── handler/         # Pipeline orchestration
 ├── planner/         # Execution planning & dependency resolution
-├── service/         # API/auth implementations
+├── service/         # Source integrations (REST, databases, SDKs, …)
+├── collector/       # Collection strategy during extraction
 ├── loader/          # Data destinations (local filesystem, S3, …)
 ├── parser/          # Lightweight transformations
 ├── config/          # Config parsing and models
+├── auth/            # JWT providers for oauth_jwt
+├── audit/           # Optional audit trail recording
 ├── utils/
 └── main.py
 ```
@@ -121,7 +124,7 @@ src/
 | **Backfill** | [Date-range backfill, inclusive flag, API lag](docs/configuration/backfill.md) |
 | **Loading** | [Delta modes: overwrite, append, merge](docs/configuration/loading.md) |
 | **Auth** | [OAuth JWT, bearer token, API key](docs/configuration/auth.md) |
-| **Transformations** | [add_column, add_column_from_request, ensure_param_values](docs/configuration/transformations.md) |
+| **Transformations** | [add_column, add_column_from_request, ensure_param_values_in_output](docs/configuration/transformations.md) |
 | **Deployment** | [Docker, GitHub Actions, GHCR](docs/deployment.md) |
 | **ECS / Fargate + S3 (reference)** | [S3 push/pull boto3, IAM, ECS task def](docs/deployment/ecs-s3-reference.md) |
 | **Development** | [Linting, testing, debugging, extending](docs/development.md) |

--- a/config/defaults.example.yml
+++ b/config/defaults.example.yml
@@ -6,6 +6,9 @@ defaults:
     initial_delay: 1
     backoff_factor: 2
 
+  # Default is false, when true, run Spark df.count() for exact row totals in logs and summaries (full scan).
+  log_full_row_count: false
+
   # Default loading: local Delta; relative storage_root resolves under the repository
   #   root (dir containing src/), e.g. repo/.spine/local-output (gitignored).
   # Override per resource if needed, or replace this block with S3 (see commented example below).
@@ -15,7 +18,7 @@ defaults:
     write_mode: "overwrite"
     compression: "snappy"
     storage_root: ".spine/local-output"
-    prefix: "default/output"
+    # Omit prefix to write under ``{source_name}/{resource_name}`` (set at runtime).
 
   # For Amazon S3 instead, use something like:
   # loading:

--- a/config/examples/postgres.example.yml
+++ b/config/examples/postgres.example.yml
@@ -6,7 +6,7 @@
 #   3. Rename `resources` keys and adjust `database_schema` / `database_table` to match your tables.
 #   4. Set `enabled: true` on the source (and resources) when you are ready to run.
 #
-# SAP HANA uses the same layout with `type: hana`; you need the HANA driver in your runtime image.
+# SAP HANA uses the same layout with `type: hana`; Spark loads the SAP ngdbc JDBC driver via packages.
 enabled: false
 type: postgresql
 host: ${PG_HOST:-localhost}
@@ -40,7 +40,7 @@ resources:
     #   # lower_bound: 1
     #   # upper_bound: 1000000
     #   # num_partitions: 8
-    #   # log_exact_row_count: false   # default: skip df.count() when parallel read is configured
+    #   # log_exact_row_count: true   # opt-in: full df.count() after JDBC read (expensive)
     #   # Or use predicates instead of partition_column (mutually exclusive):
     #   # predicates: ["id < 500000", "id >= 500000"]
     fields:
@@ -48,5 +48,5 @@ resources:
         source: id
       - name: name
         source: name
-    # Omit per-resource loading to use the defaults from `config/defaults.yml` (bucket, format, prefix, etc.).
-    loading: null
+    # Omit per-resource `loading` to inherit defaults from `config/defaults.yml` (prefix becomes
+    # `{source_name}/{resource_name}` at runtime). Use `loading: { enabled: false }` to skip writes.

--- a/docs/configuration/backfill.md
+++ b/docs/configuration/backfill.md
@@ -1,6 +1,6 @@
 # Backfill Configuration
 
-Date-range backfill splits historical data fetching into multiple API requests with fixed-size date windows. Configure backfill under **request_inputs** for body inputs: use a `value` that is a dict containing a **backfill** key (e.g. `request_inputs.startDate.value.backfill`).
+Date-range backfill splits historical data fetching into multiple API requests with fixed-size date windows. Configure backfill under **request_inputs** on **path**, **query**, or **body** inputs (same rules as normal inputs: GET defaults to query, POST defaults to body unless you set `location`). Use a `value` that is a dict containing a **backfill** key (e.g. `request_inputs.startDate.value.backfill`).
 
 ## Table of Contents
 
@@ -21,11 +21,13 @@ Backfill can run in two ways:
 
 ## Configuration Shape
 
-Backfill requires exactly two body request inputs (in `request_inputs`) whose `value` contains a **backfill** key:
+Backfill requires exactly two request inputs (in `request_inputs`, any of path / query / body) whose `value` contains a **backfill** key:
 
 - **Driver (STATIC_DATE)**: Defines the sequence of window starts. Requires `start`, `end`, and `increment`. Supports static YYYY-MM-DD strings or dynamic values (e.g. `type: DATE`, `operation: TODAY`).
 
 - **Reference (REFERENCE)**: Defines the window end for each start. References the driver field, adds `increment`, and caps at `limit`. Requires `field`, `increment`, and `limit`.
+
+Only **one** such pair is allowed per resource. You may place the driver on one location (e.g. query) and the reference on another (e.g. body); that still drives **one** sequence of windows per request batch, not two independent backfills or a Cartesian product. If the merged `request_inputs` contain more than one valid `STATIC_DATE` driver or more than one valid `REFERENCE`, plan build fails with a clear error.
 
 ## Date Pair Generation
 
@@ -63,7 +65,7 @@ This caps the last window's `endDate` at the latest date the API supports.
 
 ## Example
 
-Minimal backfill config (body request inputs with `value` containing `backfill`):
+Minimal backfill config (POST body example; `value` contains `backfill`):
 
 ```yaml
 request_inputs:
@@ -89,4 +91,4 @@ exclude_from_request_body:
   - endDate
 ```
 
-This produces 15-day windows from 2026-01-01 up to 2 days ago. List backfill driver/reference keys in **exclude_from_request_body** so they are not sent in the API body.
+This produces 15-day windows from 2026-01-01 up to 2 days ago. For **body** inputs, list backfill driver/reference keys in **exclude_from_request_body** when those keys must not appear in the JSON body (they still drive date windows and request context). Query and path parameters are sent as usual for each backfill window.

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -69,23 +69,27 @@ sources:
 |-------|-------------|
 | [Request inputs](parameters.md) | Request inputs (path/query/body), static/dynamic, SOURCE, DATABRICKS, DATE, batching, formats, shorthand, headers, POST body |
 | [Backfill](backfill.md) | Date-range backfill for body request inputs |
-| [Loading](loading.md) | Delta save modes (overwrite, append, merge), S3 |
+| [Loading](loading.md) | Delta save modes (overwrite, append, merge), S3, local |
 | [Auth](auth.md) | OAuth JWT, bearer token, API key |
 | [Transformations](transformations.md) | add_column, add_column_from_request, ensure_param_values_in_output |
-| **PostgreSQL / HANA** | `type: postgresql` or `type: hana` with JDBC-style connection fields. PostgreSQL requires `database`. For HANA, `database` is the **tenant database name** passed to hdbcli as `databaseName` (must match a real tenant; errors such as `database '…' not connected` usually mean the wrong name). It can be omitted when your `host:port` already targets a single tenant. See [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml). |
+| **PostgreSQL / HANA** | `type: postgresql` or `type: hana` with JDBC-style connection fields. PostgreSQL requires `database`. For HANA, `database` is the optional **tenant database name** sent as the JDBC `databaseName` parameter (must match a real tenant when your SQL port is shared). Omit it when `host:port` already targets a single tenant. Runtime images need the SAP **ngdbc** JAR on the Spark classpath (Spine adds `com.sap.cloud.db.jdbc:ngdbc` via `spark.jars.packages`). See [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml). |
 
 ### Spark JDBC read tuning (database resources)
 
-Optional **`table_read_options`** describes **Spark `DataFrameReader.jdbc`** options: parallel range reads, predicate lists, JDBC `fetchSize`, and whether to run an exact `count()` after the read for logs. That matches sources whose service implementation reads through Spark JDBC (for example **PostgreSQL** in this repository).
-
-Other database source types may use a different read path (for example HANA today uses SQLAlchemy on the driver). For those, the same YAML block is **rejected at config validation until implemented** for that source type, so configuration stays portable without implying unsupported features are active.
+Optional **`table_read_options`** describes **Spark `DataFrameReader.jdbc`** options: parallel range reads, predicate lists, JDBC `fetchSize`, and whether to run an exact `count()` after the read for logs. **PostgreSQL** and **HANA** both read through Spark JDBC in this repository, so the same block is honored for those `type` values. Future relational source types may reject the block until they use the same Spark read path.
 
 - **`fetch_size`**: optional JDBC `fetchSize` hint (positive integer) in Spark connection properties when the backend uses Spark JDBC.
 - **Range partitioning** (mutually exclusive with `predicates`): **`partition_column`**, **`lower_bound`**, **`upper_bound`**, **`num_partitions`**. Bounds are **operator-supplied** (Spine does not infer min/max). The column must suit Spark’s JDBC partitioner (typically an integer key).
 - **`predicates`**: non-empty list of `WHERE` fragments for predicate-based JDBC reads. Do not combine with range mode fields.
-- **`log_exact_row_count`**: when `true`, run `df.count()` after read for exact logging (extra scan). When `false` and a parallel read is configured, that count is skipped.
+- **`log_exact_row_count`**: when `true`, run `df.count()` after the JDBC read for exact logging (extra scan). When `false` (default), that count is skipped unless **`defaults.log_full_row_count`** is `true` in `defaults.yml`.
 
 Future JDBC-backed sources (for example MySQL or Redshift) can reuse this block once they use the same Spark read path. See commented examples in [config/examples/postgres.example.yml](../../config/examples/postgres.example.yml).
+
+### Default loading and row counts
+
+- **`defaults.loading`** is merged into every resource that does not define its own `loading` block (and `loading: null` in YAML is treated the same as omitted: inherit defaults). For **`local`** and **`s3`** destinations, if **`prefix`** is omitted, the handler sets **`{source_name}/{resource_name}`** before writing.
+- **`loading.enabled`**: after merging defaults, set **`enabled: false`** on a resource to skip loader writes for that resource only.
+- **`defaults.log_full_row_count`**: when **`true`**, the handler runs a full Spark **`df.count()`** for result summaries and enables the same global behavior for database extracts unless a resource opts in with **`table_read_options.log_exact_row_count`**. When **`false`** (default), the handler uses a lightweight non-empty check instead of a full count, and database extracts skip **`df.count()`** unless **`table_read_options.log_exact_row_count`** is **`true`** for that resource.
 
 ### Database resources and request contexts
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -68,7 +68,7 @@ sources:
 | Topic | Description |
 |-------|-------------|
 | [Request inputs](parameters.md) | Request inputs (path/query/body), static/dynamic, SOURCE, DATABRICKS, DATE, batching, formats, shorthand, headers, POST body |
-| [Backfill](backfill.md) | Date-range backfill for body request inputs |
+| [Backfill](backfill.md) | Date-range backfill for path, query, or body request inputs |
 | [Loading](loading.md) | Delta save modes (overwrite, append, merge), S3, local |
 | [Auth](auth.md) | OAuth JWT, bearer token, API key |
 | [Transformations](transformations.md) | add_column, add_column_from_request, ensure_param_values_in_output |

--- a/docs/configuration/value-resolution.md
+++ b/docs/configuration/value-resolution.md
@@ -97,7 +97,7 @@ request_inputs:
 
 ## Backfill Config
 
-Backfill for body inputs uses a `value` dict with a `backfill` key. Jinja can be used for dynamic `end` and `limit`:
+Backfill for path, query, or body inputs uses a `value` dict with a `backfill` key. Jinja can be used for dynamic `end` and `limit`:
 
 ```yaml
 request_inputs:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ For active development: customizing configs, debugging, or contributing.
 ### Prerequisites
 
 - Python 3.12+ and [uv](https://docs.astral.sh/uv/getting-started/installation/)
-- **Java 17** (required for Spark)
+- **Java 17+** (required for Spark)
 - Redis 7.0+ (for context management)
 - Loading destination credentials, if your configuration needs them (for example AWS when using **`destination: s3`**)
 - API credentials for your data sources
@@ -76,7 +76,7 @@ For active development: customizing configs, debugging, or contributing.
    cp config/examples/jsonplaceholder.yml config/sources/jsonplaceholder.yml
    ```
 
-2. **Install Java 17** (required for Spark)
+2. **Install Java 17+** (required for Spark)
    ```bash
    # macOS
    brew install openjdk@17
@@ -85,7 +85,7 @@ For active development: customizing configs, debugging, or contributing.
    sudo apt-get update
    sudo apt-get install openjdk-17-jdk
 
-   java -version  # Should show Java 17
+   java -version  # Should show Java 17+
    ```
 
 3. **Install Python dependencies**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "cryptography==42.0.5",
     "databricks-sdk==0.68.0",
     "delta-spark==3.1.0",
-    "hdbcli==2.23.27",
     "Jinja2>=3.1.0",
     "pandas==2.2.3",
     "psutil==7.1.3",
@@ -23,8 +22,6 @@ dependencies = [
     "PyYAML==6.0.1",
     "redis==5.0.1",
     "requests==2.31.0",
-    "sqlalchemy-hana==0.5.0",
-    "sqlalchemy==1.4.54",
 ]
 
 [dependency-groups]

--- a/src/config/backfill_config.py
+++ b/src/config/backfill_config.py
@@ -1,9 +1,13 @@
 """
 Backfill configuration parsing for date-range backfill.
 
-Backfill is detected from body inputs whose value is a dict containing "backfill".
-Callers pass a body-like dict (e.g. from request_inputs with location=body, key -> config.value).
-Supports STATIC_DATE (driver) and REFERENCE (tied to driver) types.
+Backfill is detected from request inputs (path, query, or body) whose ``value`` is a
+dict containing ``backfill``. Callers pass a flat name -> ``value`` map (e.g. from
+``ResourceConfig.get_request_input_values_for_backfill()``).
+
+Each resource supports a single driver/reference pair: one ``STATIC_DATE`` and one
+``REFERENCE``. Extra valid blocks raise ``ValueError`` (wrapped as ``PlanningError``
+during plan build).
 """
 
 from dataclasses import dataclass
@@ -31,7 +35,7 @@ class BackfillStaticDateConfig:
 class BackfillReferenceConfig:
     """Reference backfill: value = driver_field + increment, capped at limit."""
 
-    field: str  # request_body key this references (e.g. startDate)
+    field: str  # request input name of the driver (e.g. startDate)
     increment: str  # e.g. '15 DAY'
     limit: Any  # str or dict for dynamic (e.g. type: DATE, operation: TODAY)
 
@@ -40,11 +44,11 @@ class BackfillReferenceConfig:
 class BackfillConfig:
     """Parsed backfill configuration for a resource."""
 
-    driver_key: str  # request_body key that drives the ranges (e.g. startDate)
-    reference_key: str  # request_body key tied to driver (e.g. endDate)
+    driver_key: str  # request input name that drives the ranges (e.g. startDate)
+    reference_key: str  # request input name tied to driver (e.g. endDate)
     driver_config: BackfillStaticDateConfig
     reference_config: BackfillReferenceConfig
-    request_body_keys: List[str]  # [driver_key, reference_key] for injection
+    field_keys: List[str]  # [driver_key, reference_key]; injected into request context
 
 
 def parse_increment(increment_str: str) -> relativedelta:
@@ -84,21 +88,24 @@ def parse_increment(increment_str: str) -> relativedelta:
     raise ValueError(f"increment unit must be DAY, WEEK, or MONTH, got: {unit!r}")
 
 
-def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[BackfillConfig]:
+def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[BackfillConfig]:
     """
-    Detect and parse backfill configuration from resource request body inputs.
+    Detect and parse backfill configuration from resource request input values.
 
-    Looks for one driver field (backfill.type: STATIC_DATE) and one reference
-    field (backfill.type: REFERENCE, field: <driver_key>). Returns None if
-    backfill is not configured or config is invalid.
+    Each resource supports **at most one** date-range backfill: one ``STATIC_DATE``
+    driver and one ``REFERENCE`` tied to that driver. The driver and reference may
+    live on different ``request_inputs`` locations (path, query, body); that still
+    produces a single stream of date windows, not a Cartesian product of multiple
+    backfills.
 
-    Args:
-        request_body: Resource body-input dict (may contain nested backfill).
+    Raises:
+        ValueError: If more than one valid driver or more than one valid reference
+            is present (duplicate ``backfill`` blocks).
 
     Returns:
         BackfillConfig if valid backfill is configured, else None.
     """
-    if not request_body or not isinstance(request_body, dict):
+    if not input_values or not isinstance(input_values, dict):
         return None
 
     driver_key: Optional[str] = None
@@ -106,7 +113,7 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
     reference_key: Optional[str] = None
     reference_config: Optional[BackfillReferenceConfig] = None
 
-    for key, value in request_body.items():
+    for key, value in input_values.items():
         if not isinstance(value, dict) or "backfill" not in value:
             continue
         backfill = value.get("backfill")
@@ -114,9 +121,6 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
             continue
         bf_type = (backfill.get("type") or "").strip().upper()
         if bf_type == BACKFILL_TYPE_STATIC_DATE:
-            if driver_key is not None:
-                # Only one driver supported
-                continue
             start = backfill.get("start")
             end = backfill.get("end")
             increment = backfill.get("increment")
@@ -124,15 +128,23 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
                 continue
             inclusive = backfill.get("inclusive", False)
             try:
-                driver_config = BackfillStaticDateConfig(
+                candidate_driver = BackfillStaticDateConfig(
                     start=start,
                     end=end,
                     increment=str(increment).strip(),
                     inclusive=bool(inclusive),
                 )
-                parse_increment(driver_config.increment)
+                parse_increment(candidate_driver.increment)
             except (ValueError, TypeError):
                 continue
+            if driver_key is not None:
+                raise ValueError(
+                    "Backfill allows at most one STATIC_DATE driver per resource; "
+                    f"found another on input {key!r} (first driver: {driver_key!r}). "
+                    "Splitting start/end across path, query, or body is fine; defining "
+                    "two independent driver blocks is not."
+                )
+            driver_config = candidate_driver
             driver_key = key
         elif bf_type == BACKFILL_TYPE_REFERENCE:
             ref_field = backfill.get("field")
@@ -141,14 +153,21 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
             if not ref_field or not ref_increment or limit is None:
                 continue
             try:
-                reference_config = BackfillReferenceConfig(
+                candidate_reference = BackfillReferenceConfig(
                     field=str(ref_field).strip(),
                     increment=str(ref_increment).strip(),
                     limit=limit,
                 )
-                parse_increment(reference_config.increment)
+                parse_increment(candidate_reference.increment)
             except (ValueError, TypeError):
                 continue
+            if reference_key is not None:
+                raise ValueError(
+                    "Backfill allows at most one REFERENCE field per resource; "
+                    f"found another on input {key!r} (first reference: {reference_key!r}). "
+                    "Use exactly one driver/reference pair."
+                )
+            reference_config = candidate_reference
             reference_key = key
 
     if (
@@ -166,5 +185,5 @@ def get_backfill_config(request_body: Optional[Dict[str, Any]]) -> Optional[Back
         reference_key=reference_key,
         driver_config=driver_config,
         reference_config=reference_config,
-        request_body_keys=[driver_key, reference_key],
+        field_keys=[driver_key, reference_key],
     )

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -912,6 +912,22 @@ class ResourceConfig(BaseModel):
             if config.location == location
         }
 
+    def get_request_input_values_for_backfill(self) -> Dict[str, Any]:
+        """
+        Flat map of input name to configured ``value`` for backfill detection.
+
+        Merges path, then query, then body inputs. Input names are unique per
+        resource, so order only matters if that invariant were violated.
+
+        Returns:
+            Empty dict when there are no request_inputs.
+        """
+        merged: Dict[str, Any] = {}
+        for loc in ("path", "query", "body"):
+            for name, cfg in self.get_inputs_by_location(loc).items():
+                merged[name] = cfg.value
+        return merged
+
     def get_batch_inputs(self) -> Dict[str, RequestInputConfig]:
         """
         Get request inputs that require batching (any location).

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -4,6 +4,7 @@ Uses Pydantic for validation and type safety.
 """
 
 import ast
+import copy
 import json
 from enum import Enum, StrEnum
 from pathlib import Path
@@ -42,8 +43,10 @@ class RetryConfig(BaseModel):
 class LoadingConfig(BaseModel):
     """
     Data loading configuration.
-    For S3 and local destinations, prefix must be specified and should follow the pattern:
-    'source_name/resource_name' (e.g., 'my_source/users').
+    For S3 and local destinations, prefix should follow ``source_name/resource_name``
+    (e.g. ``my_source/users``). When prefix is omitted, the handler fills it from the
+    source and resource name at runtime.
+
     For S3, the actual Parquet data will be stored in a 'data' subdirectory under this prefix.
 
     Save modes for Delta format:
@@ -56,6 +59,13 @@ class LoadingConfig(BaseModel):
     to be added to existing tables.
     """
 
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "When false, skip loader writes for this resource (use after merging defaults). "
+            "Omit ``loading`` on a resource to inherit defaults; set ``enabled: false`` to opt out."
+        ),
+    )
     destination: str
     format: str = "delta"
     write_mode: Literal["overwrite", "append", "merge", "ignore", "error"] = "overwrite"
@@ -83,13 +93,15 @@ class LoadingConfig(BaseModel):
     @classmethod
     def validate_prefix(cls, v: Optional[str], info: ValidationInfo) -> Optional[str]:
         """Validate prefix format for S3 and local filesystem destinations."""
+        if not info.data.get("enabled", True):
+            return v
         dest = info.data.get("destination")
         if dest in ("s3", "local"):
-            if not v:
-                raise ValueError(f"prefix is required for {dest} destinations")
+            if v is None or not str(v).strip():
+                return None
 
             # Remove any leading/trailing slashes
-            v = v.strip("/")
+            v = str(v).strip("/")
 
             # Check prefix structure (should be at least source/resource)
             parts = v.split("/")
@@ -118,6 +130,8 @@ class LoadingConfig(BaseModel):
         Raises:
             ValueError: If write_mode is 'merge' but merge_keys is not provided or is empty
         """
+        if not self.enabled:
+            return self
         if self.write_mode == "merge":
             if not self.merge_keys:
                 raise ValueError(
@@ -131,6 +145,8 @@ class LoadingConfig(BaseModel):
     @model_validator(mode="after")
     def validate_destination_storage_fields(self) -> "LoadingConfig":
         """Require bucket (S3) or storage_root (local); runs after merge_keys check."""
+        if not self.enabled:
+            return self
         if self.destination == "s3":
             if not self.bucket:
                 raise ValueError("bucket is required for S3 destination")
@@ -689,7 +705,8 @@ class TableReadOptions(BaseModel):
 
     Use either **range partitioning** (partition_column + bounds + num_partitions) or
     **predicates** (list of WHERE fragments for parallel reads), not both.
-    Source types that do not read via Spark JDBC yet reject this block at validation time.
+    Honored for relational sources that extract via Spark JDBC (PostgreSQL, HANA). Other
+    database kinds may reject this block at validation until they use the same read path.
     """
 
     fetch_size: Optional[int] = Field(
@@ -721,8 +738,9 @@ class TableReadOptions(BaseModel):
     log_exact_row_count: bool = Field(
         default=False,
         description=(
-            "When True, run df.count() after read for exact row logging (full scan). "
-            "When False and a parallel read is configured, row count is omitted to avoid an extra scan."
+            "When True, run df.count() after JDBC read for exact row logging (full scan). "
+            "When False (default), that count is skipped for this resource. Also applies to "
+            "non-parallel reads unless defaults.log_full_row_count is True."
         ),
     )
 
@@ -837,8 +855,8 @@ class ResourceConfig(BaseModel):
         default=None,
         description=(
             "Optional table read tuning (Spark JDBC partitioning, fetch size, logging). "
-            "Honored when the source service uses Spark read.jdbc; other database implementations "
-            "may reject this block until they support the same read path."
+            "Honored for PostgreSQL and HANA sources (Spark read.jdbc). Other database kinds may "
+            "reject this block until they support the same read path."
         ),
     )
 
@@ -990,31 +1008,36 @@ class ResourceConfig(BaseModel):
         # Get defaults from parent if available
         defaults = data.pop("_defaults", None)
         if defaults and isinstance(defaults, dict):
-            # Deep merge loading config with defaults (only if resource doesn't explicitly set loading to None)
+            # Deep merge loading config with defaults (inherit when omitted; opt out with enabled: false)
             if "loading" in defaults:
-                default_loading = defaults["loading"]
+                default_loading = copy.deepcopy(defaults["loading"])
                 resource_loading = data.get("loading")
 
-                # If resource explicitly sets loading to None, skip merging (keep it None)
-                # Otherwise, merge with defaults
-                if resource_loading is not None:
-                    # Merge loading configuration (resource_loading may be dict or missing)
+                if resource_loading is None:
+                    data["loading"] = default_loading
+                else:
                     if not isinstance(resource_loading, dict):
                         resource_loading = {}
-                    data["loading"] = {
-                        **default_loading,  # Start with defaults
-                        **resource_loading,  # Override with resource-specific settings
-                    }
-                # If resource_loading is None, leave it as None (explicitly skipped)
+                    data["loading"] = {**default_loading, **resource_loading}
 
         super().__init__(**data)
 
-        # Validate loading destination fields (only if loading is configured)
-        if self.loading and self.loading.destination == "s3" and not self.loading.bucket:
+        # Validate loading destination fields (only if loading is configured and enabled)
+        if (
+            self.loading
+            and self.loading.enabled
+            and self.loading.destination == "s3"
+            and not self.loading.bucket
+        ):
             raise ValueError(
                 "bucket is required for S3 destination (either in defaults or resource configuration)"
             )
-        if self.loading and self.loading.destination == "local" and not self.loading.storage_root:
+        if (
+            self.loading
+            and self.loading.enabled
+            and self.loading.destination == "local"
+            and not self.loading.storage_root
+        ):
             raise ValueError(
                 "storage_root is required for local destination (either in defaults or resource configuration)"
             )
@@ -1062,8 +1085,8 @@ class SourceConfig(BaseModel):
         default=None,
         description=(
             "Database/catalog name. Required for postgresql. "
-            "Optional for hana: set to the HANA tenant database name when using a shared SQL port; "
-            "omit when the host:port already targets a single tenant."
+            "Optional for hana: set to the HANA tenant database name (JDBC databaseName) when "
+            "using a shared SQL port; omit when the host:port already targets a single tenant."
         ),
     )
     connection_params: Optional[Dict[str, Any]] = Field(
@@ -1092,11 +1115,6 @@ class SourceConfig(BaseModel):
             for resource_name, resource in self.resources.items():
                 if not resource.enabled:
                     continue
-                if resource.table_read_options is not None and self.type == SourceType.HANA:
-                    raise ValueError(
-                        f"{self.type.value} resource '{resource_name}' cannot use table_read_options "
-                        "until this source type reads via Spark JDBC (hana uses a different extract path today)"
-                    )
                 sch = (resource.database_schema or "").strip()
                 tbl = (resource.database_table or "").strip()
                 if not sch or not tbl:
@@ -1220,6 +1238,15 @@ class DefaultsConfig(BaseModel):
     retry: RetryConfig = Field(
         default_factory=RetryConfig, description="Default retry configuration"
     )
+    log_full_row_count: bool = Field(
+        default=False,
+        description=(
+            "When True, run Spark df.count() for exact row totals in handler summaries and "
+            "allow the same for database extracts unless overridden per-resource. When False "
+            "(default), database extracts skip full counts unless table_read_options.log_exact_row_count "
+            "is set, and the handler uses a lightweight non-empty check instead of counting all rows."
+        ),
+    )
     loading: LoadingConfig = Field(
         default_factory=lambda: LoadingConfig(
             destination="local",
@@ -1227,12 +1254,12 @@ class DefaultsConfig(BaseModel):
             write_mode="overwrite",
             compression="snappy",
             storage_root=".spine/local-output",
-            prefix="default/output",
+            prefix=None,
         ),
         description=(
-            "Default loading when ``defaults.loading`` is omitted from YAML: local Delta under "
-            "``.spine/local-output`` (relative to the repository root, next to ``config/`` in a normal checkout) "
-            "with placeholder prefix; override for S3 or real paths."
+            "Default loading merged into every resource unless the resource sets loading.enabled "
+            "to false. Prefix may be omitted; the handler sets ``{source_name}/{resource_name}`` "
+            "before load when prefix is unset for local or S3 destinations."
         ),
     )
     context: ContextConfig = Field(

--- a/src/config/config_spark.py
+++ b/src/config/config_spark.py
@@ -6,6 +6,12 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
+# Maven coordinates Spark resolves at startup (Ivy). Keep ngdbc pin aligned with smoke testing.
+_HADOOP_AWS_PKG = "org.apache.hadoop:hadoop-aws:3.3.4"
+_DELTA_PKG = "io.delta:delta-spark_2.12:3.1.0"
+_SAP_NGDBC_PKG = "com.sap.cloud.db.jdbc:ngdbc:2.23.10"
+SPARK_JARS_PACKAGES = f"{_HADOOP_AWS_PKG},{_DELTA_PKG},{_SAP_NGDBC_PKG}"
+
 
 class ConfigSpark:
     """Configuration for Spark session."""
@@ -19,7 +25,7 @@ class ConfigSpark:
         # Set Spark packages (including Delta Lake)
         # PySpark 3.5.x uses Scala 2.12, so we use delta-spark_2.12
         os.environ["PYSPARK_SUBMIT_ARGS"] = (
-            "--packages org.apache.hadoop:hadoop-aws:3.3.4,io.delta:delta-spark_2.12:3.1.0 "
+            f"--packages {SPARK_JARS_PACKAGES} "
             "--conf spark.ui.showConsoleProgress=false "
             "pyspark-shell"
         )
@@ -62,7 +68,7 @@ class ConfigSpark:
             "spark.metrics.enabled": "false",
             # Delta Lake configuration
             # Add Delta Lake JARs via packages (PySpark 3.5.x uses Scala 2.12)
-            "spark.jars.packages": "org.apache.hadoop:hadoop-aws:3.3.4,io.delta:delta-spark_2.12:3.1.0",
+            "spark.jars.packages": SPARK_JARS_PACKAGES,
             # Enable Delta SQL extensions
             "spark.sql.extensions": "io.delta.sql.DeltaSparkSessionExtension",
             # Configure Delta catalog
@@ -91,7 +97,7 @@ class ConfigSpark:
             "spark.driver.memory": "4g",
             # Delta Lake configuration
             # Add Delta Lake JARs via packages (PySpark 3.5.x uses Scala 2.12)
-            "spark.jars.packages": "org.apache.hadoop:hadoop-aws:3.3.4,io.delta:delta-spark_2.12:3.1.0",
+            "spark.jars.packages": SPARK_JARS_PACKAGES,
             # Enable Delta SQL extensions
             "spark.sql.extensions": "io.delta.sql.DeltaSparkSessionExtension",
             # Configure Delta catalog

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -37,18 +37,19 @@ def _resolve_pipeline_config_dir(config_path_setting: str) -> Path:
 class SparkSettings(BaseSettings):
     """Spark-specific settings."""
 
+    model_config = SettingsConfigDict(extra="ignore")
+
     APP_NAME: str = "DataIngestion"
     MASTER: str = "local[*]"
     DRIVER_MEMORY: str = "4g"
     MEMORY_FRACTION: float = 0.8
     MEMORY_STORAGE_FRACTION: float = 0.3
 
-    class Config:
-        extra = "ignore"
-
 
 class APISettings(BaseSettings):
     """API-specific settings."""
+
+    model_config = SettingsConfigDict(extra="ignore")
 
     TIMEOUT: int = Field(default=30, description="Request timeout in seconds")
 
@@ -71,12 +72,11 @@ class APISettings(BaseSettings):
             self.INITIAL_DELAY = config.defaults.retry.initial_delay
             self.RETRY_BACKOFF = config.defaults.retry.backoff_factor
 
-    class Config:
-        extra = "ignore"
-
 
 class AWSSettings(BaseSettings):
     """AWS-specific settings."""
+
+    model_config = SettingsConfigDict(extra="ignore")
 
     REGION: str = Field(default="ap-southeast-2", description="AWS region")
 
@@ -91,9 +91,6 @@ class AWSSettings(BaseSettings):
         except AWSError as e:
             logger.error("Failed to initialize AWS settings", extra_fields={"error": str(e)})
             raise
-
-    class Config:
-        extra = "ignore"
 
 
 class DatabricksSettings(BaseSettings):

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -20,6 +20,7 @@ from src.collector import (
 from src.config.config_models import (
     BatchSizeMode,
     InputConfig,
+    LoadingConfig,
     PaginationConfig,
     PaginationType,
     ResourceConfig,
@@ -128,6 +129,25 @@ class DynamicHandler(BaseHandler):
 
         # Create execution plan
         self.execution_plan = ExecutionPlan(self.config, self.redis_context, selection=selection)
+
+    def _resolve_resource_loading(
+        self, source_name: str, resource_name: str, resource_config: ResourceConfig
+    ) -> Optional[LoadingConfig]:
+        """
+        Effective loading for this resource: merged defaults with optional ``source/resource`` prefix.
+
+        Returns None when loading is disabled (``enabled: false`` after merge).
+        """
+        loading = resource_config.loading
+        if loading is None:
+            loading = self.config.defaults.loading
+        if not loading.enabled:
+            return None
+        if loading.destination in ("s3", "local"):
+            prefix = (loading.prefix or "").strip()
+            if not prefix:
+                return loading.model_copy(update={"prefix": f"{source_name}/{resource_name}"})
+        return loading
 
     def _apply_request_limit(
         self,
@@ -1962,6 +1982,10 @@ class DynamicHandler(BaseHandler):
                     extra_fields={"resource_name": resource_name},
                 )
 
+            effective_loading = self._resolve_resource_loading(
+                source_name, resource_name, resource_config
+            )
+
             # Decide whether to use backfill date ranges (manual --backfill or auto on first write)
             use_backfill = False
             if not is_db and resource_meta.backfill_config:
@@ -1971,16 +1995,16 @@ class DynamicHandler(BaseHandler):
                         "Backfill enabled by CLI for resource",
                         extra_fields={"resource_name": resource_name, "source": source_name},
                     )
-                elif resource_config.loading and self.record_limit is None:
+                elif effective_loading and self.record_limit is None:
                     try:
-                        loader = LoaderFactory.create_loader(resource_config.loading)
+                        loader = LoaderFactory.create_loader(effective_loading)
                         if hasattr(loader, "set_spark_session") and self.spark:
                             loader.set_spark_session(self.spark)
                         if hasattr(loader, "destination_exists"):
                             source_config = self.execution_plan.get_source_config(source_name)
                             source_type = source_config.type if source_config else None
                             exists = loader.destination_exists(
-                                resource_config.loading, source_type=source_type
+                                effective_loading, source_type=source_type
                             )
                             if not exists:
                                 use_backfill = True
@@ -1999,7 +2023,7 @@ class DynamicHandler(BaseHandler):
                                 "error": str(e),
                             },
                         )
-                elif not resource_config.loading and self.record_limit is None:
+                elif not effective_loading and self.record_limit is None:
                     # Snapshot trigger pattern: resource has no loading but dependents do
                     # Check dependents' destinations; if any is empty, trigger backfill
                     dependent_loadings = self.execution_plan.get_dependent_loading_configs(
@@ -2101,7 +2125,11 @@ class DynamicHandler(BaseHandler):
                         "Finalized streaming collector",
                         extra_fields={
                             "has_transformations": bool(resource_meta.config.transformations),
-                            "record_count": all_data_df.count() if all_data_df else 0,
+                            "record_count": (
+                                all_data_df.count()
+                                if all_data_df and self.config.defaults.log_full_row_count
+                                else None
+                            ),
                             "collector_type": type(collector).__name__,
                         },
                     )
@@ -2136,7 +2164,11 @@ class DynamicHandler(BaseHandler):
                     self.logger.trace(
                         "Applying transformations to complete data",
                         extra_fields={
-                            "record_count": all_data_df.count(),
+                            "record_count": (
+                                all_data_df.count()
+                                if self.config.defaults.log_full_row_count
+                                else None
+                            ),
                             "transformation_count": len(resource_meta.config.transformations),
                         },
                     )
@@ -2177,9 +2209,14 @@ class DynamicHandler(BaseHandler):
             # Store and process results
             try:
                 if all_data_df is not None:
-                    record_count = all_data_df.count()
+                    if self.config.defaults.log_full_row_count:
+                        record_count = all_data_df.count()
+                        has_data = record_count > 0
+                    else:
+                        has_data = len(all_data_df.take(1)) > 0
+                        record_count = None
 
-                    if record_count > 0:
+                    if has_data:
                         # Store in Redis only when this resource has downstream dependents (needed for SOURCE params)
                         dependent_resources = self.execution_plan.get_dependent_resources(
                             source_name, resource_name
@@ -2198,8 +2235,8 @@ class DynamicHandler(BaseHandler):
 
                         # Load data if we have records and loading is configured
                         location = None
-                        if self.record_limit is None and resource_config.loading:
-                            loader = LoaderFactory.create_loader(resource_config.loading)
+                        if self.record_limit is None and effective_loading:
+                            loader = LoaderFactory.create_loader(effective_loading)
                             if hasattr(loader, "set_spark_session"):
                                 loader.set_spark_session(self.spark)
 
@@ -2209,7 +2246,7 @@ class DynamicHandler(BaseHandler):
 
                             location = loader.load(
                                 data=all_data_df,
-                                config=resource_config.loading,
+                                config=effective_loading,
                                 source_type=source_type,
                             )
 
@@ -2394,7 +2431,7 @@ class DynamicHandler(BaseHandler):
                             extra_fields={
                                 "result_summary": {
                                     "status": resource_result.get("status", "success"),
-                                    "record_count": resource_result.get("count", 0),
+                                    "record_count": resource_result.get("count"),
                                     "location": resource_result.get("location"),
                                 }
                             },
@@ -2561,20 +2598,23 @@ class DynamicHandler(BaseHandler):
                                     f"Invalid schema field in {resource_name}: name is required"
                                 )
 
-                    # Validate loading configuration (if provided)
-                    if resource_config.loading:
-                        if resource_config.loading.destination == "s3":
-                            if not resource_config.loading.bucket:
+                    # Validate loading configuration (effective merge + auto prefix)
+                    eff_loading = self._resolve_resource_loading(
+                        source_name, resource_name, resource_config
+                    )
+                    if eff_loading:
+                        if eff_loading.destination == "s3":
+                            if not eff_loading.bucket:
                                 raise HandlerError(
                                     f"Missing S3 bucket configuration for resource: {resource_name}"
                                 )
-                            s3_buckets.add(resource_config.loading.bucket)
-                        elif resource_config.loading.destination == "local":
-                            if not resource_config.loading.storage_root:
+                            s3_buckets.add(eff_loading.bucket)
+                        elif eff_loading.destination == "local":
+                            if not eff_loading.storage_root:
                                 raise HandlerError(
                                     f"Missing storage_root for local loading on resource: {resource_name}"
                                 )
-                            local_storage_roots.add(resource_config.loading.storage_root)
+                            local_storage_roots.add(eff_loading.storage_root)
 
                 self.logger.info(f"Successfully validated source: {source_name}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -156,7 +156,7 @@ def run_pipeline(
                                 extra_fields={
                                     "source": source_name,
                                     "resource_name": resource_name,
-                                    "count": details["count"],
+                                    "count": details.get("count"),
                                     "location": details.get("location"),
                                 },
                             )

--- a/src/main.py
+++ b/src/main.py
@@ -79,7 +79,7 @@ def run_pipeline(
         log_level: Optional log level to override environment variable
         selection: Optional selection structure mapping source names to resource name sets.
                    None means all resources, Set[str] means specific resource names.
-        limit: Optional limit on fetch operations per resource (for development/testing). When used, data is not saved to S3.
+        limit: Optional limit on fetch operations per resource (for development/testing). When set, data is not written to the configured loading destination.
         backfill: If True, use backfill date ranges for resources that have backfill config (manual backfill).
 
     Returns:
@@ -226,7 +226,10 @@ def run_pipeline(
     "--limit",
     "-l",
     type=click.IntRange(min=0),
-    help="Limit number of fetch operations per resource (useful for testing, 0=skip resource). When used, data is NOT saved to S3.",
+    help=(
+        "Limit number of fetch operations per resource (useful for testing, 0=skip resource). "
+        "When set, data is NOT written to the configured loading destination."
+    ),
     default=None,
 )
 @click.option(

--- a/src/planner/execution_plan.py
+++ b/src/planner/execution_plan.py
@@ -48,7 +48,7 @@ class ResourceMetadata:
     parent_fields: Set[str] = None  # Fields that need to be carried from parent context
     config: ResourceConfig = None  # Reference to the resource configuration
     backfill_config: Optional[BackfillConfig] = (
-        None  # Request-body date-range backfill, if configured
+        None  # Request-input date-range backfill (path/query/body), if configured
     )
 
     def estimate_request_count(self) -> Optional[int]:
@@ -561,10 +561,16 @@ class ExecutionPlan:
                         if source_config.field:
                             parent_fields.add(source_config.field)
 
-                # Backfill from body inputs: value may be a dict with "backfill" key
-                body_inputs = resource.get_inputs_by_location("body")
-                body_dict = {n: c.value for n, c in body_inputs.items()} if body_inputs else None
-                backfill_cfg = get_backfill_config(body_dict)
+                # Backfill: value may be a dict with "backfill" on path, query, or body inputs
+                inputs_for_backfill = resource.get_request_input_values_for_backfill()
+                try:
+                    backfill_cfg = get_backfill_config(inputs_for_backfill or None)
+                except ValueError as e:
+                    raise PlanningError(
+                        message="Invalid backfill configuration",
+                        operation="_build_resource_metadata",
+                        details={"resource": resource_id, "error": str(e)},
+                    ) from e
                 self._resource_metadata[resource_id] = ResourceMetadata(
                     source_name=source_name,
                     resource_name=resource_name,

--- a/src/planner/execution_plan.py
+++ b/src/planner/execution_plan.py
@@ -855,7 +855,12 @@ class ExecutionPlan:
             dep_source, dep_resource = dep_id.split(".", 1)
             dep_config = self.get_resource_config(dep_source, dep_resource)
             dep_source_config = self.get_source_config(dep_source)
-            if dep_config and dep_config.loading and dep_source_config:
+            if (
+                dep_config
+                and dep_config.loading
+                and dep_config.loading.enabled
+                and dep_source_config
+            ):
                 result.append((dep_config.loading, dep_source_config.type))
         return result
 

--- a/src/service/hana_service.py
+++ b/src/service/hana_service.py
@@ -1,12 +1,9 @@
-"""SAP HANA ingestion via SQLAlchemy and Spark (driver-side fetch; not distributed)."""
+"""SAP HANA ingestion via Spark JDBC (SAP ngdbc driver)."""
 
-import warnings
-from typing import Any, Optional
+from typing import Optional
 from urllib.parse import quote_plus
 
-from pyspark.sql import DataFrame, Row, SparkSession
-from sqlalchemy import create_engine, text
-from sqlalchemy.exc import SAWarning
+from pyspark.sql import DataFrame, SparkSession
 
 from src.config.config_models import SourceConfig, SourceType, TableReadOptions
 from src.config.settings import Settings
@@ -16,7 +13,9 @@ from src.utils.redis_context import RedisContextManager
 
 
 class HanaService(SqlDatabaseService):
-    """HANA using SQLAlchemy; rows are fetched on the driver then converted to a DataFrame."""
+    """SAP HANA using Spark JDBC (same read tuning model as PostgreSQL)."""
+
+    HANA_JDBC_DRIVER = "com.sap.db.jdbc.Driver"
 
     def __init__(
         self,
@@ -34,49 +33,29 @@ class HanaService(SqlDatabaseService):
         super().__init__(settings, source_name, config, redis_context)
         self._engine_label = "SAP HANA"
         self._extract_object_kind = "table/view"
-        self._engine: Any = None
-        warnings.filterwarnings(
-            "ignore",
-            r"Dialect hana:hdbcli will not make use of SQL compilation caching",
-            SAWarning,
-        )
 
     def connect(self) -> None:
         try:
             self._validate_host_and_port_for_connect()
-            connection_string = self._build_connection_string()
-            self._engine = create_engine(connection_string)
-            with self._engine.connect() as connection:
-                connection.execute(text("SELECT 1 FROM DUMMY"))
             self._is_connected = True
         except ServiceError:
             raise
         except Exception as e:
             raise ServiceError(
-                message=f"Failed to connect to HANA database: {e!s}",
+                message=f"Failed to validate HANA connection settings: {e!s}",
                 service_name=self.__class__.__name__,
                 operation="connect",
                 original_error=e,
             ) from e
 
     def close(self) -> None:
-        if self._engine is not None:
-            try:
-                self._engine.dispose()
-            finally:
-                self._engine = None
-                self._is_connected = False
-
-    def _ensure_extract_prerequisites(self) -> None:
-        if not self._is_connected or self._engine is None:
-            raise ServiceError(
-                message="HANA service is not connected. Call connect() first.",
-                service_name=self.__class__.__name__,
-                operation="extract_table",
-            )
+        self._is_connected = False
 
     def _table_label_for_log(self, schema: str, table: str) -> str:
         return f'"{schema}"."{table}"' if schema else f'"{table}"'
+
+    def _quoted_from_clause(self, schema: str, table: str) -> str:
+        return self._table_label_for_log(schema, table)
 
     def _load_dataframe(
         self,
@@ -86,49 +65,63 @@ class HanaService(SqlDatabaseService):
         select_query: Optional[str],
         table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
-        _ = table_read_options  # HANA reads via SQLAlchemy, not Spark read.jdbc; tuning not applied here yet.
-        table_ref = self._table_label_for_log(schema, table)
+        jdbc_url = self._build_jdbc_url()
+        table_ref = self._quoted_from_clause(schema, table)
+
         if select_query:
             query = select_query
         else:
-            query = f"SELECT * FROM {table_ref}"
+            query = f"(SELECT * FROM {table_ref}) AS data_query"
 
-        with self._engine.connect() as connection:
-            result = connection.execute(text(query))
+        connection_properties: dict[str, str] = {
+            "driver": self.HANA_JDBC_DRIVER,
+            "user": self.config.username or "",
+            "password": self.config.password or "",
+        }
+        if self.config.connection_params:
+            for k, v in self.config.connection_params.items():
+                connection_properties[str(k)] = str(v)
+        if table_read_options is not None and table_read_options.fetch_size is not None:
+            connection_properties["fetchsize"] = str(table_read_options.fetch_size)
 
-            if not result.returns_rows:
-                raise ServiceError(
-                    message="Query did not return any rows",
-                    service_name=self.__class__.__name__,
-                    operation="extract_table",
-                )
-
-            rows = result.fetchall()
-            columns = list(result.keys())
-
-            spark_rows = []
-            for row in rows:
-                try:
-                    row_dict = {col: row[col] for col in columns}
-                except (TypeError, KeyError):
-                    row_dict = {col: row[idx] for idx, col in enumerate(columns)}
-                spark_rows.append(Row(**row_dict))
-
-            return spark_session.createDataFrame(spark_rows)
-
-    def _build_connection_string(self) -> str:
-        password = quote_plus(self.config.password or "")
-        connection_string = (
-            f"hana://{self.config.username}:{password}@"
-            f"{self.config.host}:{int(self.config.port)}"
+        reader = spark_session.read
+        if table_read_options is not None and table_read_options.predicates:
+            return reader.jdbc(
+                url=jdbc_url,
+                table=query,
+                predicates=table_read_options.predicates,
+                properties=connection_properties,
+            )
+        if table_read_options is not None and (table_read_options.partition_column or "").strip():
+            col = table_read_options.partition_column.strip()
+            return reader.jdbc(
+                url=jdbc_url,
+                table=query,
+                column=col,
+                lowerBound=table_read_options.lower_bound,
+                upperBound=table_read_options.upper_bound,
+                numPartitions=table_read_options.num_partitions,
+                properties=connection_properties,
+            )
+        return reader.jdbc(
+            url=jdbc_url,
+            table=query,
+            properties=connection_properties,
         )
-        # hdbcli `databaseName` must match a real HANA tenant; omit URL path when unset so
-        # tenant-scoped SQL ports (common on BW) can connect without a bogus placeholder.
+
+    def _build_jdbc_url(self) -> str:
+        port = int(self.config.port)  # type: ignore[arg-type]
+        base = f"jdbc:sap://{self.config.host}:{port}/"
+        parts: list[str] = []
         db = (self.config.database or "").strip()
         if db:
-            connection_string = f"{connection_string}/{db}"
+            parts.append(f"databaseName={quote_plus(db)}")
         if self.config.connection_params:
-            param_parts = [f"{key}={value}" for key, value in self.config.connection_params.items()]
-            if param_parts:
-                connection_string = f"{connection_string}?{'&'.join(param_parts)}"
-        return connection_string
+            for k, v in self.config.connection_params.items():
+                key = str(k)
+                if key.lower() in ("user", "password", "driver"):
+                    continue
+                parts.append(f"{key}={quote_plus(str(v))}")
+        if parts:
+            return f"{base}?{'&'.join(parts)}"
+        return base

--- a/src/service/sql_database_service.py
+++ b/src/service/sql_database_service.py
@@ -167,9 +167,10 @@ class SqlDatabaseService(BaseSourceService, ABC):
                     extra_log["partition_column"] = table_read_options.partition_column.strip()
                     extra_log["num_partitions"] = table_read_options.num_partitions
 
-            should_count = True
-            if table_read_options is not None and table_read_options.uses_parallel_read():
-                should_count = table_read_options.log_exact_row_count
+            defaults = self.settings.pipeline_config.defaults
+            should_count = defaults.log_full_row_count or (
+                table_read_options is not None and table_read_options.log_exact_row_count
+            )
 
             if should_count:
                 row_count = df.count()
@@ -179,8 +180,8 @@ class SqlDatabaseService(BaseSourceService, ABC):
                 )
             else:
                 logger.info(
-                    f"Successfully extracted from '{table_label}' (parallel JDBC read; "
-                    f"exact row count skipped; set table_read_options.log_exact_row_count to count)",
+                    f"Successfully extracted from '{table_label}' (exact row count skipped; "
+                    f"set defaults.log_full_row_count or table_read_options.log_exact_row_count for counts)",
                     extra_fields=extra_log,
                 )
             return df

--- a/src/utils/dynamic_values.py
+++ b/src/utils/dynamic_values.py
@@ -384,7 +384,7 @@ class DynamicValueResolver:
 
         # Handle dictionary format for complex values
         if isinstance(value, dict) and not isinstance(value, (DynamicValue, ComplexDynamicValue)):
-            # Handle flat DATE format (type, operation, days at top level) - used by request_body backfill
+            # Handle flat DATE format (type, operation, days at top level) - used by backfill limits
             if "type" in value:
                 try:
                     dynamic_type = DynamicValueType(value["type"].upper())

--- a/tests/test_config/test_backfill_config.py
+++ b/tests/test_config/test_backfill_config.py
@@ -1,0 +1,203 @@
+"""Tests for backfill config detection from request input values."""
+
+import pytest
+
+from src.config.backfill_config import get_backfill_config
+from src.config.config_models import ResourceConfig
+
+
+def test_get_backfill_config_query_style_flat_dict() -> None:
+    """GET-style query parameters (snake_case) with nested value + backfill."""
+    input_values = {
+        "start_date": {
+            "value": "{{ date('PREVIOUS_SUNDAY') }}",
+            "backfill": {
+                "type": "STATIC_DATE",
+                "start": "2021-01-03",
+                "end": "2026-04-21",
+                "inclusive": False,
+                "increment": "1 WEEK",
+            },
+        },
+        "end_date": {
+            "value": "{{ date('PREVIOUS_SATURDAY') }}",
+            "backfill": {
+                "type": "REFERENCE",
+                "field": "start_date",
+                "increment": "7 DAY",
+                "limit": "2026-04-14",
+            },
+        },
+    }
+    cfg = get_backfill_config(input_values)
+    assert cfg is not None
+    assert cfg.driver_key == "start_date"
+    assert cfg.reference_key == "end_date"
+    assert cfg.reference_config.field == "start_date"
+    assert cfg.field_keys == ["start_date", "end_date"]
+
+
+def test_get_backfill_config_body_style_flat_dict() -> None:
+    """POST body camelCase keys (doc example shape)."""
+    input_values = {
+        "startDate": {
+            "value": "{{ date('DAYS_AGO', days=9) }}",
+            "backfill": {
+                "type": "STATIC_DATE",
+                "start": "2026-01-01",
+                "end": "2026-04-21",
+                "inclusive": False,
+                "increment": "15 DAY",
+            },
+        },
+        "endDate": {
+            "value": "{{ date('DAYS_AGO', days=2) }}",
+            "backfill": {
+                "type": "REFERENCE",
+                "field": "startDate",
+                "increment": "15 DAY",
+                "limit": "2026-04-14",
+            },
+        },
+    }
+    cfg = get_backfill_config(input_values)
+    assert cfg is not None
+    assert cfg.driver_key == "startDate"
+    assert cfg.reference_key == "endDate"
+
+
+def test_get_backfill_config_mixed_query_without_backfill_and_body_backfill() -> None:
+    """Non-backfill query keys must not prevent detecting body backfill."""
+    input_values = {
+        "advertiser_id": {"type": "SOURCE"},
+        "startDate": {
+            "value": "x",
+            "backfill": {
+                "type": "STATIC_DATE",
+                "start": "2026-01-01",
+                "end": "2026-01-31",
+                "increment": "15 DAY",
+            },
+        },
+        "endDate": {
+            "value": "y",
+            "backfill": {
+                "type": "REFERENCE",
+                "field": "startDate",
+                "increment": "15 DAY",
+                "limit": "2026-01-31",
+            },
+        },
+    }
+    cfg = get_backfill_config(input_values)
+    assert cfg is not None
+    assert cfg.driver_key == "startDate"
+
+
+def test_get_request_input_values_for_backfill_merges_path_query_body() -> None:
+    """ResourceConfig merges locations in path → query → body order."""
+    # Use dict-shaped inputs (as YAML does); passing RequestInputConfig instances as
+    # top-level values is incorrect because normalize_request_inputs wraps non-dicts.
+    resource = ResourceConfig(
+        method="GET",
+        path="/accounts/{account_id}/reports",
+        request_inputs={
+            "account_id": {"value": "123456", "location": "path"},
+            "start_date": {
+                "value": {
+                    "value": "{{ date('PREVIOUS_SUNDAY') }}",
+                    "backfill": {
+                        "type": "STATIC_DATE",
+                        "start": "2021-01-03",
+                        "end": "2026-04-21",
+                        "inclusive": False,
+                        "increment": "1 WEEK",
+                    },
+                },
+                "location": "query",
+            },
+            "end_date": {
+                "value": {
+                    "value": "{{ date('PREVIOUS_SATURDAY') }}",
+                    "backfill": {
+                        "type": "REFERENCE",
+                        "field": "start_date",
+                        "increment": "7 DAY",
+                        "limit": "2026-04-14",
+                    },
+                },
+                "location": "query",
+            },
+        },
+    )
+    merged = resource.get_request_input_values_for_backfill()
+    assert set(merged.keys()) == {"account_id", "start_date", "end_date"}
+    cfg = get_backfill_config(merged)
+    assert cfg is not None
+    assert cfg.driver_key == "start_date"
+
+
+def test_get_backfill_config_empty_returns_none() -> None:
+    assert get_backfill_config({}) is None
+    assert get_backfill_config(None) is None
+
+
+def _valid_static_backfill(start: str = "2026-01-01") -> dict:
+    return {
+        "type": "STATIC_DATE",
+        "start": start,
+        "end": "2026-01-31",
+        "increment": "15 DAY",
+    }
+
+
+def _valid_reference(field: str = "start_date") -> dict:
+    return {
+        "type": "REFERENCE",
+        "field": field,
+        "increment": "15 DAY",
+        "limit": "2026-01-31",
+    }
+
+
+def test_get_backfill_config_rejects_second_static_date_driver() -> None:
+    with pytest.raises(ValueError, match="at most one STATIC_DATE"):
+        get_backfill_config(
+            {
+                "start_date": {"value": "a", "backfill": _valid_static_backfill("2026-01-01")},
+                "other_start": {"value": "b", "backfill": _valid_static_backfill("2026-02-01")},
+                "end_date": {"value": "c", "backfill": _valid_reference("start_date")},
+            }
+        )
+
+
+def test_get_backfill_config_rejects_second_reference() -> None:
+    with pytest.raises(ValueError, match="at most one REFERENCE"):
+        get_backfill_config(
+            {
+                "start_date": {"value": "a", "backfill": _valid_static_backfill()},
+                "end_date": {"value": "b", "backfill": _valid_reference("start_date")},
+                "alt_end": {"value": "c", "backfill": _valid_reference("start_date")},
+            }
+        )
+
+
+def test_get_backfill_config_allows_invalid_second_static_without_raise() -> None:
+    """A second STATIC_DATE block that fails validation is ignored (not a duplicate driver)."""
+    cfg = get_backfill_config(
+        {
+            "start_date": {"value": "a", "backfill": _valid_static_backfill()},
+            "broken": {
+                "value": "b",
+                "backfill": {
+                    "type": "STATIC_DATE",
+                    "start": "2026-01-01",
+                    "end": "2026-01-31",
+                    "increment": "not-a-valid-increment",
+                },
+            },
+            "end_date": {"value": "c", "backfill": _valid_reference("start_date")},
+        }
+    )
+    assert cfg is not None
+    assert cfg.driver_key == "start_date"

--- a/tests/test_config/test_defaults_config_loading.py
+++ b/tests/test_config/test_defaults_config_loading.py
@@ -1,6 +1,6 @@
 """Tests for DefaultsConfig.loading built-in default."""
 
-from src.config.config_models import DefaultsConfig, LoadingConfig
+from src.config.config_models import DefaultsConfig, LoadingConfig, ResourceConfig
 
 
 def test_defaults_config_loading_factory_is_local_delta() -> None:
@@ -10,8 +10,9 @@ def test_defaults_config_loading_factory_is_local_delta() -> None:
     assert d.loading.write_mode == "overwrite"
     assert d.loading.compression == "snappy"
     assert d.loading.storage_root == ".spine/local-output"
-    assert d.loading.prefix == "default/output"
+    assert d.loading.prefix is None
     assert d.loading.bucket is None
+    assert d.loading.enabled is True
 
 
 def test_defaults_config_explicit_loading_overrides() -> None:
@@ -25,3 +26,28 @@ def test_defaults_config_explicit_loading_overrides() -> None:
     )
     assert d.loading.destination == "s3"
     assert d.loading.bucket == "b"
+
+
+def test_resource_config_inherits_defaults_loading_when_loading_omitted() -> None:
+    defaults = DefaultsConfig().model_dump()
+    r = ResourceConfig(
+        method="GET",
+        path="/api",
+        _defaults=defaults,
+    )
+    assert r.loading is not None
+    assert r.loading.destination == "local"
+    assert r.loading.prefix is None
+
+
+def test_resource_config_merge_respects_loading_enabled_false() -> None:
+    defaults = DefaultsConfig().model_dump()
+    r = ResourceConfig(
+        method="GET",
+        path="/api",
+        loading={"enabled": False},
+        _defaults=defaults,
+    )
+    assert r.loading is not None
+    assert r.loading.enabled is False
+    assert r.loading.destination == "local"

--- a/tests/test_config/test_loading_config.py
+++ b/tests/test_config/test_loading_config.py
@@ -67,3 +67,23 @@ def test_loading_config_merge_requires_keys() -> None:
             format="delta",
             write_mode="merge",
         )
+
+
+def test_loading_config_local_prefix_optional() -> None:
+    cfg = LoadingConfig(
+        destination="local",
+        storage_root="/tmp/spine",
+        prefix=None,
+        format="delta",
+    )
+    assert cfg.prefix is None
+
+
+def test_loading_config_disabled_skips_bucket_and_prefix_rules() -> None:
+    cfg = LoadingConfig(
+        enabled=False,
+        destination="s3",
+        format="delta",
+        prefix="any",
+    )
+    assert cfg.enabled is False

--- a/tests/test_config/test_table_read_options_config.py
+++ b/tests/test_config/test_table_read_options_config.py
@@ -87,22 +87,24 @@ def test_postgres_allows_table_read_options() -> None:
     )
 
 
-def test_hana_rejects_table_read_options() -> None:
-    with pytest.raises(ValidationError) as exc:
-        SourceConfig(
-            type=SourceType.HANA,
-            host="localhost",
-            port=30015,
-            username="u",
-            password="p",
-            resources={
-                "t": ResourceConfig(
-                    method="GET",
-                    database_schema="S",
-                    database_table="T",
-                    table_read_options=TableReadOptions(fetch_size=500),
-                )
-            },
-        )
-    msg = str(exc.value).lower()
-    assert "table_read_options" in msg or "spark" in msg or "hana" in msg
+def test_hana_allows_table_read_options() -> None:
+    SourceConfig(
+        type=SourceType.HANA,
+        host="localhost",
+        port=30015,
+        username="u",
+        password="p",
+        resources={
+            "t": ResourceConfig(
+                method="GET",
+                database_schema="S",
+                database_table="T",
+                table_read_options=TableReadOptions(
+                    partition_column="id",
+                    lower_bound=0,
+                    upper_bound=99,
+                    num_partitions=2,
+                ),
+            )
+        },
+    )

--- a/tests/test_utils/test_backfill_dates.py
+++ b/tests/test_utils/test_backfill_dates.py
@@ -35,7 +35,7 @@ def _make_config(inclusive: bool, limit_str: str) -> BackfillConfig:
         reference_key="endDate",
         driver_config=driver,
         reference_config=reference,
-        request_body_keys=["startDate", "endDate"],
+        field_keys=["startDate", "endDate"],
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -417,59 +417,6 @@ wheels = [
 ]
 
 [[package]]
-name = "greenlet"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
-    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
-    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
-    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
-    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
-    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
-    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
-]
-
-[[package]]
-name = "hdbcli"
-version = "2.23.27"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/6e/15da733bdcc4af5889cb9f8e08d0b411db4b985bb2758ce42bcc4eb26f98/hdbcli-2.23.27-cp34-abi3-macosx_10_11_x86_64.whl", hash = "sha256:fa374b439493e653fb57b9f03dde78daf7fa00053abb424f61f48cbe431a232a", size = 5562463, upload-time = "2025-02-05T14:18:08.254Z" },
-    { url = "https://files.pythonhosted.org/packages/26/5e/2a2ac180ec34efb9ef39eeb59041881dbdd945f1782a897386d75043dca9/hdbcli-2.23.27-cp34-abi3-manylinux1_x86_64.whl", hash = "sha256:2cbe9d84af3e00489d59afdc8e0c4c1c59f722fef9a6da161ee6b9a71be9c080", size = 11268239, upload-time = "2025-02-05T14:18:16.118Z" },
-    { url = "https://files.pythonhosted.org/packages/00/39/0fd40b6ed0256470e02cd39ffd79f1805769744c4b4c2f8dded6efdc8c51/hdbcli-2.23.27-cp34-abi3-manylinux2014_ppc64le.whl", hash = "sha256:3dac578618cc93774bcc88e612893931e22dfd408dfe393696568980d095071a", size = 11347009, upload-time = "2025-02-05T14:18:20.058Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/2d/71177be91d7a26e566d75ccffb27ebe627bb8daef29ffee3e889f3b158a0/hdbcli-2.23.27-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:0451b25065a72a4021a432e11b92305b467324d5b8f7857aecda90b822d362fa", size = 11180128, upload-time = "2025-02-05T14:18:24.888Z" },
-    { url = "https://files.pythonhosted.org/packages/46/60/aa202a9d8dc78c8e3679e94fae316c58de59585ec828ba6829a2e7a00a13/hdbcli-2.23.27-cp36-abi3-win32.whl", hash = "sha256:704a4db7ceec2a6720d8f45ebe1b1d2e58bf63ccf2a98b32cc21fab35e4dced6", size = 3615143, upload-time = "2025-02-05T14:18:28.572Z" },
-    { url = "https://files.pythonhosted.org/packages/53/6f/99e308b2ebbdfd740191959850ff5a9368bf7dcadc5b27eea70906c4c453/hdbcli-2.23.27-cp36-abi3-win_amd64.whl", hash = "sha256:1b7fc5a77be5050b25daee19c934a14ccca4a1444ad5e03086ee2759759212d1", size = 3615148, upload-time = "2025-02-05T14:18:31.526Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/b9/a8fc747338be1837fc809b509f6a8986fa2519d23a8dd4a34c5cb5c7e0c0/hdbcli-2.23.27-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:5a608df24dc0603347af6f0764262eaae8d5c4f38fa65d8a45a9f8013da05897", size = 4994642, upload-time = "2025-02-05T14:18:34.709Z" },
-]
-
-[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1219,7 +1166,6 @@ dependencies = [
     { name = "cryptography" },
     { name = "databricks-sdk" },
     { name = "delta-spark" },
-    { name = "hdbcli" },
     { name = "jinja2" },
     { name = "pandas" },
     { name = "psutil" },
@@ -1232,8 +1178,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "requests" },
-    { name = "sqlalchemy" },
-    { name = "sqlalchemy-hana" },
 ]
 
 [package.dev-dependencies]
@@ -1254,7 +1198,6 @@ requires-dist = [
     { name = "cryptography", specifier = "==42.0.5" },
     { name = "databricks-sdk", specifier = "==0.68.0" },
     { name = "delta-spark", specifier = "==3.1.0" },
-    { name = "hdbcli", specifier = "==2.23.27" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "pandas", specifier = "==2.2.3" },
     { name = "psutil", specifier = "==7.1.3" },
@@ -1267,8 +1210,6 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "redis", specifier = "==5.0.1" },
     { name = "requests", specifier = "==2.31.0" },
-    { name = "sqlalchemy", specifier = "==1.4.54" },
-    { name = "sqlalchemy-hana", specifier = "==0.5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1281,31 +1222,6 @@ dev = [
     { name = "ruff", specifier = "==0.15.2" },
     { name = "yamllint", specifier = "==1.38.0" },
 ]
-
-[[package]]
-name = "sqlalchemy"
-version = "1.4.54"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/af/20290b55d469e873cba9d41c0206ab5461ff49d759989b3fe65010f9d265/sqlalchemy-1.4.54.tar.gz", hash = "sha256:4470fbed088c35dc20b78a39aaf4ae54fe81790c783b3264872a0224f437c31a", size = 8470350, upload-time = "2024-09-05T15:54:10.398Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/1b/aa9b99be95d1615f058b5827447c18505b7b3f1dfcbd6ce1b331c2107152/SQLAlchemy-1.4.54-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:3f01c2629a7d6b30d8afe0326b8c649b74825a0e1ebdcb01e8ffd1c920deb07d", size = 1589983, upload-time = "2024-09-05T17:39:02.132Z" },
-    { url = "https://files.pythonhosted.org/packages/59/47/cb0fc64e5344f0a3d02216796c342525ab283f8f052d1c31a1d487d08aa0/SQLAlchemy-1.4.54-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c24dd161c06992ed16c5e528a75878edbaeced5660c3db88c820f1f0d3fe1f4", size = 1630158, upload-time = "2024-09-05T17:50:13.255Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/8b/f45dd378f6c97e8ff9332ff3d03ecb0b8c491be5bb7a698783b5a2f358ec/SQLAlchemy-1.4.54-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5e0d47d619c739bdc636bbe007da4519fc953393304a5943e0b5aec96c9877c", size = 1629232, upload-time = "2024-09-05T17:48:15.514Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/3c/884fe389f5bec86a310b81e79abaa1e26e5d78dc10a84d544a6822833e47/SQLAlchemy-1.4.54-cp312-cp312-win32.whl", hash = "sha256:12bc0141b245918b80d9d17eca94663dbd3f5266ac77a0be60750f36102bbb0f", size = 1592027, upload-time = "2024-09-05T17:54:02.253Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c3/c690d037be57efd3a69cde16a2ef1bd2a905dafe869434d33836de0983d0/SQLAlchemy-1.4.54-cp312-cp312-win_amd64.whl", hash = "sha256:f941aaf15f47f316123e1933f9ea91a6efda73a161a6ab6046d1cde37be62c88", size = 1593827, upload-time = "2024-09-05T17:52:07.454Z" },
-]
-
-[[package]]
-name = "sqlalchemy-hana"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sqlalchemy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/40/aea04b711f4095bcc8b7270f353af57e4b1fb9b61bcaf65bdcb669ce0975/sqlalchemy-hana-0.5.0.tar.gz", hash = "sha256:473fab3488fd885212aeb2dba2603091fe4d9212487f7ff826c59d8bf6ce4504", size = 24030, upload-time = "2020-07-22T11:47:42.252Z" }
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary

| PR | What |
|----|------|
| #30 | Align documentation with the current file layout |
| #31 | Align Databricks settings with the Pydantic v2 / pydantic-settings pattern used elsewhere |
| #32 | HANA via Spark JDBC (`ngdbc`); `table_read_options` normalization; safer default row counting (exact count opt-in); loading defaults / path resolution and explicit load opt-out |
| #33 | Backfill planning reads driver fields from **path, query, and body** (not body-only); `BackfillConfig.field_keys` |

## Release notes (user-facing)

- **Databases:** HANA extraction aligned with **Spark JDBC** (`ngdbc`) and shared **`table_read_options`** behavior with PostgreSQL.
- **Operations:** Default **exact `df.count()`** logging is **off** unless enabled via config or per-resource options.
- **Loading:** Resources inherit defaults, resolve output paths as `source/resource` when unset, and support **`loading: { enabled: false }`** to skip loads.
- **Backfill:** Backfill-related inputs are honored when provided on **query or path** as well as the body (fixes GET-style resources with date fields on query).
- **Config:** Databricks **settings** follow the same **Pydantic v2** style as other environments.
- **Docs:** Small **structure/layout** doc fixes (#30).

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

- #30
- #31
- #32
- #33