### PR TITLE
Feature/iceberg support

### DIFF
--- a/config/defaults.example.yml
+++ b/config/defaults.example.yml
@@ -57,4 +57,7 @@ defaults:
 
 # Named SQL files live under config/queries/ (operator-local, not committed).
 # See config/examples/sample_query.sql for a minimal template.
-queries: []
+queries:
+  - name: "example_query"
+    description: "An example SQL query loaded from a file."
+    file: "example_query.sql"

--- a/config/defaults.example.yml
+++ b/config/defaults.example.yml
@@ -57,7 +57,9 @@ defaults:
 
 # Named SQL files live under config/queries/ (operator-local, not committed).
 # See config/examples/sample_query.sql for a minimal template.
-queries:
-  - name: "example_query"
-    description: "An example SQL query loaded from a file."
-    file: "example_query.sql"
+queries: []
+# To enable file-backed queries, first create the SQL file under config/queries/, then
+# add entries like:
+#   - name: "example_query"
+#     description: "An example SQL query loaded from a file."
+#     file: "example_query.sql"

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -5,4 +5,5 @@ These files are **templates** only. Copy them into `config/sources/` and adjust 
 | File | Description |
 |------|-------------|
 | [`jsonplaceholder.yml`](jsonplaceholder.yml) | REST source against [JSONPlaceholder](https://jsonplaceholder.typicode.com/) (public test API). Dependencies between resources demonstrate `SOURCE`-style parameters. |
+| [`jsonplaceholder.iceberg.append.yml`](jsonplaceholder.iceberg.append.yml) | REST source example showing Iceberg append writes to a warehouse-relative path that resolves to a catalog-backed table (for example, `jsonplaceholder/posts` -> `iceberg.jsonplaceholder.posts`). |
 | [`postgres.example.yml`](postgres.example.yml) | PostgreSQL / relational source shape (placeholders for host, database, credentials). |

--- a/config/examples/jsonplaceholder.iceberg.append.yml
+++ b/config/examples/jsonplaceholder.iceberg.append.yml
@@ -1,0 +1,41 @@
+enabled: false
+type: "rest_api"
+base_url: "https://jsonplaceholder.typicode.com/"
+
+# Example source config for Iceberg append writes.
+#
+# This writes the JsonPlaceholder `posts` resource as an Iceberg table using
+# append mode. The `prefix` is warehouse-relative and becomes the table path
+# under the configured warehouse root. With the local example below, the loader
+# resolves this to a catalog-backed Iceberg table equivalent to:
+#   iceberg.jsonplaceholder.posts
+#
+# To switch this example to S3, replace the `loading` block with:
+#   destination: "s3"
+#   bucket: "your-bucket-name"
+#   format: "iceberg"
+#   write_mode: "append"
+#   prefix: "jsonplaceholder/posts"
+
+resources:
+  posts:
+    path: "posts"
+    method: "GET"
+    response_type: "json"
+
+    fields:
+      - name: "user_id"
+        source: "userId"
+      - name: "id"
+        source: "id"
+      - name: "title"
+        source: "title"
+      - name: "body"
+        source: "body"
+
+    loading:
+      destination: "local"
+      storage_root: ".spine/local-iceberg-warehouse"
+      format: "iceberg"
+      write_mode: "append"
+      prefix: "jsonplaceholder/posts"

--- a/docker/README.md
+++ b/docker/README.md
@@ -183,3 +183,7 @@ docker build --platform linux/amd64 ...
 - The container uses Python 3.12 and OpenJDK 21 for Spark
 - Redis runs in-memory inside the container
 - Mount `.env` as read-only (`:ro`) for security
+- Iceberg support increases Spark startup dependency resolution and can modestly increase image-related pull/build time expectations because the Spark package list now includes the Iceberg runtime alongside Delta, Hadoop AWS, and ngdbc
+- No new Python packages were added for Iceberg support; the change is limited to Spark packages and Spark SQL extensions configured in `src/config/config_spark.py`
+- Iceberg writes use Spark DataSourceV2 functionality, and merge operations use Spark SQL functionality
+- We intentionally did not add PyIceberg because configuring PyIceberg would be a pain in the ass

--- a/docker/README.md
+++ b/docker/README.md
@@ -183,7 +183,4 @@ docker build --platform linux/amd64 ...
 - The container uses Python 3.12 and OpenJDK 21 for Spark
 - Redis runs in-memory inside the container
 - Mount `.env` as read-only (`:ro`) for security
-- Iceberg support increases Spark startup dependency resolution and can modestly increase image-related pull/build time expectations because the Spark package list now includes the Iceberg runtime alongside Delta, Hadoop AWS, and ngdbc
-- No new Python packages were added for Iceberg support; the change is limited to Spark packages and Spark SQL extensions configured in `src/config/config_spark.py`
-- Iceberg writes use Spark DataSourceV2 functionality, and merge operations use Spark SQL functionality
-- We intentionally did not add PyIceberg because configuring PyIceberg would be a pain in the ass
+- Spark startup resolves several JARs at launch (Delta, Iceberg, Hadoop AWS, ngdbc); first-run dependency resolution adds time

--- a/docs/configuration/loading.md
+++ b/docs/configuration/loading.md
@@ -115,7 +115,7 @@ loading:
 
 ## Iceberg
 
-When using Iceberg format, Spine writes through the configured `iceberg` Spark catalog. The warehouse root depends on the destination: for S3 writes it is rooted at `s3://<bucket-name>`, and for local writes it is rooted at the configured `storage_root`. Spine first resolves the final table path from that warehouse root plus the configured `prefix`, then removes the warehouse root from the resolved path and converts the remaining path into a catalog table identifier by replacing `/` with `.` and prefixing it with `iceberg.`. For example, if the warehouse root is `s3://my-bucket` and the resolved table path is `s3://my-bucket/source/resource`, Spine derives the catalog table identifier `iceberg.source.resource`.
+When using Iceberg format, Spine writes through the configured `iceberg` Spark catalog. The warehouse root depends on the destination: for S3 writes it is rooted at `s3a://<bucket-name>`, and for local writes it is rooted at the configured `storage_root`. Spine first resolves the final table path from that warehouse root plus the configured `prefix`, then removes the warehouse root from the resolved path and converts the remaining path into a catalog table identifier by replacing `/` with `.` and prefixing it with `iceberg.`. For example, if the warehouse root is `s3a://my-bucket` and the resolved table path is `a://my-bucket/source/resource`, Spine derives the catalog table identifier `iceberg.source.resource`.
 
 **Available modes**: `overwrite`, `append`, `merge`
 

--- a/docs/configuration/loading.md
+++ b/docs/configuration/loading.md
@@ -10,6 +10,11 @@
   - [Overwrite](#overwrite)
   - [Append](#append)
   - [Merge (Upsert)](#merge-upsert)
+- [Iceberg](#iceberg)
+  - [Append](#append-1)
+  - [Overwrite](#overwrite-1)
+  - [Merge (preview)](#merge-preview)
+  - [Current limitations](#current-limitations)
 - [Quick reference](#quick-reference)
 
 ## Destinations
@@ -108,6 +113,62 @@ loading:
 - Supports composite keys (multiple columns)
 - Tables are created automatically if they don't exist
 
+## Iceberg
+
+When using Iceberg format, Spine writes through the configured `iceberg` Spark catalog. The warehouse root depends on the destination: for S3 writes it is rooted at `s3://<bucket-name>`, and for local writes it is rooted at the configured `storage_root`. Spine first resolves the final table path from that warehouse root plus the configured `prefix`, then removes the warehouse root from the resolved path and converts the remaining path into a catalog table identifier by replacing `/` with `.` and prefixing it with `iceberg.`. For example, if the warehouse root is `s3://my-bucket` and the resolved table path is `s3://my-bucket/source/resource`, Spine derives the catalog table identifier `iceberg.source.resource`.
+
+**Available modes**: `overwrite`, `append`, `merge`
+
+### Append
+
+Append writes add rows to the existing Iceberg table, creating the table on first write when it does not already exist.
+
+```yaml
+loading:
+  destination: "local"
+  format: "iceberg"
+  write_mode: "append"
+  storage_root: ".spine/local-iceberg-warehouse"
+  prefix: "source/resource"
+```
+
+### Overwrite
+
+Overwrite replaces the contents of the target Iceberg table.
+
+```yaml
+loading:
+  destination: "s3"
+  format: "iceberg"
+  write_mode: "overwrite"
+  bucket: "my-bucket"
+  prefix: "source/resource"
+```
+
+### Merge (preview)
+
+Merge mode performs an Iceberg `MERGE INTO` using the configured `merge_keys`. If the table does not exist yet, Spine creates it first and later runs merges against the catalog table.
+
+```yaml
+loading:
+  destination: "s3"
+  format: "iceberg"
+  write_mode: "merge"
+  merge_keys: ["id"]
+  bucket: "my-bucket"
+  prefix: "source/resource"
+```
+
+### Current limitations
+
+Iceberg support is still in an early merge-support phase. Plan around the following current behavior:
+
+- `merge_keys` is required for Iceberg merge mode
+- Merge updates only columns present in both the source data and the existing target table
+- Merge inserts are shaped to the current target schema; target-only columns are filled with typed `NULL`
+- The current merge path does not auto-evolve the target schema before `MERGE INTO`; if the source introduces new columns, use append/overwrite first or evolve the table separately
+- Iceberg table existence is currently detected from filesystem metadata under the resolved table path
+
 ## Quick reference
 
 | `destination` | Required fields | Notes |
@@ -115,5 +176,7 @@ loading:
 | `s3` | `bucket`, `prefix` | `prefix` uses the `source/resource` shape described above. Set **`destination: "s3"`** on the resource (or in defaults) whenever you set `bucket`; shallow merge with **`destination: local`** defaults would otherwise keep `local`. |
 | `local` | `storage_root`, `prefix` | `storage_root` may be absolute, or **relative to the repository root** (directory containing `src/`). Relative values are resolved when the config is loaded. |
 | *(omitted `defaults.loading`)* | *(built-in default)* | Same as **`local`** with **`storage_root: ".spine/local-output"`** (resolved under the repository root) and **`prefix: "default/output"`**; override per resource or in **`defaults.yml`**. |
+
+For table formats, `format: "delta"` and `format: "iceberg"` both use the `source/resource`-style prefix directly as the table location. For Iceberg, Spine resolves the final table path under the destination-specific warehouse root (`s3://<bucket-name>` for S3, `storage_root` for local), removes that warehouse root, and converts the remaining path into the catalog table name by replacing `/` with `.` and prefixing it with `iceberg.`.
 
 Filesystem helpers for loaders live under **`src/loader/`** (for example `object_store.py`, `local_storage.py`).

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -119,8 +119,7 @@ class LoadingConfig(BaseModel):
                 )
 
             # Ensure 'data' is not included in the prefix
-            # Delta puts data in `/data` subdirectory under the prefix, so it should not be part of the user-provided prefix
-            # Iceberg puts data in the root of the prefix, so 'data' should also not be included to avoid confusion and potential conflicts
+            # Delta appends /data under the prefix; Iceberg writes to the prefix root — neither should include 'data' explicitly
             if "data" in parts:
                 raise ValueError(
                     "prefix should not include 'data' directory - it will be automatically appended"

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -40,6 +40,13 @@ class RetryConfig(BaseModel):
     backoff_factor: float = Field(default=2.0, gt=1)
 
 
+class LoadingFormat(str, Enum):
+    """Supported loading formats."""
+
+    DELTA = "delta"
+    ICEBERG = "iceberg"
+
+
 class LoadingConfig(BaseModel):
     """
     Data loading configuration.
@@ -67,7 +74,7 @@ class LoadingConfig(BaseModel):
         ),
     )
     destination: str
-    format: str = "delta"
+    format: LoadingFormat = LoadingFormat.DELTA
     write_mode: Literal["overwrite", "append", "merge", "ignore", "error"] = "overwrite"
     compression: Optional[str] = "snappy"
     bucket: Optional[str] = None  # For S3, can be inherited from defaults
@@ -112,6 +119,8 @@ class LoadingConfig(BaseModel):
                 )
 
             # Ensure 'data' is not included in the prefix
+            # Delta puts data in `/data` subdirectory under the prefix, so it should not be part of the user-provided prefix
+            # Iceberg puts data in the root of the prefix, so 'data' should also not be included to avoid confusion and potential conflicts
             if "data" in parts:
                 raise ValueError(
                     "prefix should not include 'data' directory - it will be automatically appended"

--- a/src/config/config_spark.py
+++ b/src/config/config_spark.py
@@ -111,7 +111,7 @@ class ConfigSpark:
             "spark.sql.extensions": SPARK_EXTENSIONS,
             # Configure Delta catalog and Iceberg catalog
             "spark.sql.catalog.spark_catalog": "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-            "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkCatalog",
             "spark.sql.catalog.iceberg.type": "hadoop",
             # We will be needing to configure warehouse root for `iceberg` that will happen while loading
             # "spark.sql.catalog.iceberg.warehouse": "<warehouse_path>" -- if s3: s3a://<bucket-name> else if local: file://<storage-root>

--- a/src/config/config_spark.py
+++ b/src/config/config_spark.py
@@ -9,8 +9,13 @@ from typing import Any, Dict, Optional
 # Maven coordinates Spark resolves at startup (Ivy). Keep ngdbc pin aligned with smoke testing.
 _HADOOP_AWS_PKG = "org.apache.hadoop:hadoop-aws:3.3.4"
 _DELTA_PKG = "io.delta:delta-spark_2.12:3.1.0"
+_ICEBERG_PKG = "org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.10.1"
 _SAP_NGDBC_PKG = "com.sap.cloud.db.jdbc:ngdbc:2.23.10"
-SPARK_JARS_PACKAGES = f"{_HADOOP_AWS_PKG},{_DELTA_PKG},{_SAP_NGDBC_PKG}"
+SPARK_JARS_PACKAGES = ",".join([_HADOOP_AWS_PKG, _DELTA_PKG, _ICEBERG_PKG, _SAP_NGDBC_PKG])
+
+_ICEBERG_EXTENSIONS = "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
+_DELTA_EXTENSIONS = "io.delta.sql.DeltaSparkSessionExtension"
+SPARK_EXTENSIONS = ",".join([_ICEBERG_EXTENSIONS, _DELTA_EXTENSIONS])
 
 
 class ConfigSpark:
@@ -70,9 +75,13 @@ class ConfigSpark:
             # Add Delta Lake JARs via packages (PySpark 3.5.x uses Scala 2.12)
             "spark.jars.packages": SPARK_JARS_PACKAGES,
             # Enable Delta SQL extensions
-            "spark.sql.extensions": "io.delta.sql.DeltaSparkSessionExtension",
-            # Configure Delta catalog
+            "spark.sql.extensions": SPARK_EXTENSIONS,
+            # Configure Delta catalog and Iceberg catalog
             "spark.sql.catalog.spark_catalog": "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+            "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.iceberg.type": "hadoop",
+            # We will be needing to configure warehouse root for `iceberg` that will happen while loading
+            # "spark.sql.catalog.iceberg.warehouse": "<warehouse_path>" -- if s3: s3a://<bucket-name> else if local: file://<storage-root>
             # AWS S3 configurations
             "spark.hadoop.fs.s3a.access.key": aws_access_key,
             "spark.hadoop.fs.s3a.secret.key": aws_secret_key,
@@ -99,9 +108,13 @@ class ConfigSpark:
             # Add Delta Lake JARs via packages (PySpark 3.5.x uses Scala 2.12)
             "spark.jars.packages": SPARK_JARS_PACKAGES,
             # Enable Delta SQL extensions
-            "spark.sql.extensions": "io.delta.sql.DeltaSparkSessionExtension",
-            # Configure Delta catalog
+            "spark.sql.extensions": SPARK_EXTENSIONS,
+            # Configure Delta catalog and Iceberg catalog
             "spark.sql.catalog.spark_catalog": "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+            "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkSessionCatalog",
+            "spark.sql.catalog.iceberg.type": "hadoop",
+            # We will be needing to configure warehouse root for `iceberg` that will happen while loading
+            # "spark.sql.catalog.iceberg.warehouse": "<warehouse_path>" -- if s3: s3a://<bucket-name> else if local: file://<storage-root>
             "spark.hadoop.fs.s3a.aws.credentials.provider": "com.amazonaws.auth.DefaultAWSCredentialsProviderChain",
             "spark.hadoop.fs.s3a.endpoint": f"s3.{region}.amazonaws.com",
             "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem",

--- a/src/config/config_spark.py
+++ b/src/config/config_spark.py
@@ -113,8 +113,6 @@ class ConfigSpark:
             "spark.sql.catalog.spark_catalog": "org.apache.spark.sql.delta.catalog.DeltaCatalog",
             "spark.sql.catalog.iceberg": "org.apache.iceberg.spark.SparkCatalog",
             "spark.sql.catalog.iceberg.type": "hadoop",
-            # We will be needing to configure warehouse root for `iceberg` that will happen while loading
-            # "spark.sql.catalog.iceberg.warehouse": "<warehouse_path>" -- if s3: s3a://<bucket-name> else if local: file://<storage-root>
             "spark.hadoop.fs.s3a.aws.credentials.provider": "com.amazonaws.auth.DefaultAWSCredentialsProviderChain",
             "spark.hadoop.fs.s3a.endpoint": f"s3.{region}.amazonaws.com",
             "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem",

--- a/src/loader/s3_loader.py
+++ b/src/loader/s3_loader.py
@@ -12,7 +12,7 @@ from delta.tables import DeltaTable
 from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql.types import StructField, StructType
 
-from src.config.config_models import LoadingConfig
+from src.config.config_models import LoadingConfig, LoadingFormat
 from src.loader.base_loader import BaseLoader, LoaderError
 from src.loader.object_store import SparkFilesystemObjectStore, loading_base_uri
 from src.utils.logger import get_logger
@@ -157,12 +157,12 @@ class S3Loader(BaseLoader):
 
         return source_type_mapping.get(type_key, "")
 
-    def _prepend_source_type_prefix(self, prefix: str, source_type: Optional[str]) -> str:
+    def _prepend_source_type_prefix(self, prefix: Optional[str], source_type: Optional[str]) -> str:
         """
         Prepend source type prefix to the given prefix.
 
         Args:
-            prefix: Original prefix
+            prefix: Optional original prefix
             source_type: Source type (e.g., "rest_api", "python_sdk")
 
         Returns:
@@ -171,7 +171,7 @@ class S3Loader(BaseLoader):
         source_type_prefix = self._get_source_type_prefix(source_type)
 
         if not source_type_prefix:
-            return prefix
+            return prefix or ""
 
         # Clean both prefixes
         source_type_prefix = source_type_prefix.strip("/")
@@ -182,34 +182,28 @@ class S3Loader(BaseLoader):
         else:
             return source_type_prefix
 
-    def _generate_delta_path(
-        self, base_uri: str, prefix: str, source_type: Optional[str] = None
+    def _generate_table_path(
+        self, base_uri: str, prefix: Optional[str], source_type: Optional[str] = None
     ) -> str:
         """
-        Generate Delta table path (directory-based, not file-based).
+        Generate a table path for directory-based table formats.
 
-        Delta tables are stored as directories containing data files and metadata.
-        This method returns the directory path where the Delta table will be stored.
-        For Delta format, we use the prefix directly without adding the "data/" suffix.
-        The source type prefix is prepended automatically.
+        Table formats such as Delta and Iceberg are stored as directories containing
+        data files and format-specific metadata. This method returns the directory
+        path where the table will be stored. The source type prefix is prepended
+        automatically.
 
         Args:
             base_uri: Filesystem base URI
-            prefix: Key prefix
+            prefix: Optional key prefix
             source_type: Optional source type to prepend to the path
 
         Returns:
-            str: Delta table directory path
+            str: Table directory path
         """
-        # Prepend source type prefix if provided
         full_prefix = self._prepend_source_type_prefix(prefix, source_type)
+        clean_prefix = full_prefix.strip("/") if full_prefix else ""
 
-        # For Delta, use prefix directly without "data/" suffix
-        if not full_prefix:
-            clean_prefix = ""
-        else:
-            clean_prefix = full_prefix.strip("/")
-        # Delta tables are directories, so we return the directory path
         if clean_prefix:
             return self.object_store.resolve_path(base_uri, clean_prefix, trailing_slash=True)
         return self.object_store.resolve_path(base_uri, trailing_slash=True)
@@ -346,15 +340,56 @@ class S3Loader(BaseLoader):
         # Coalesce to single file for consistent output
         return df.coalesce(1)
 
-    @retry_on_s3_error()
-    def _write_dataframe(self, df: DataFrame, path: str, write_options: Dict[str, Any]) -> None:
+    def _get_iceberg_table_identifier(self, path: str, iceberg_warehouse_path: str) -> str:
         """
-        Write DataFrame to S3 with retry logic and optimizations.
+        Convert a warehouse-relative Iceberg table path into a quoted catalog identifier.
+
+        Args:
+            path: Fully resolved table path under the Iceberg warehouse root
+            iceberg_warehouse_path: Warehouse root configured for the `iceberg` catalog
+
+        Returns:
+            str: Quoted catalog table identifier
+
+        Raises:
+            LoaderError: If the table identifier cannot be derived from the path
+        """
+        warehouse_root = iceberg_warehouse_path.rstrip("/")
+        path_prefix = f"{warehouse_root}/"
+
+        if not path.startswith(path_prefix):
+            raise LoaderError(
+                f"Cannot derive Iceberg table identifier from path '{path}' with warehouse '{iceberg_warehouse_path}'"
+            )
+
+        table_only_path = path[len(path_prefix) :].strip("/")
+        if not table_only_path:
+            raise LoaderError(
+                f"Cannot derive Iceberg table identifier from path '{path}' with warehouse '{iceberg_warehouse_path}'"
+            )
+
+        table_parts = [part for part in table_only_path.split("/") if part]
+        return "iceberg." + ".".join(f"`{part}`" for part in table_parts)
+
+    @retry_on_s3_error()
+    def _write_dataframe(
+        self,
+        df: DataFrame,
+        path: str,
+        write_options: Dict[str, Any],
+        *,
+        iceberg: bool = False,
+        iceberg_warehouse_path: Optional[str] = None,
+    ) -> None:
+        """
+        Write a DataFrame to object storage or to a catalog-backed Iceberg table.
 
         Args:
             df: DataFrame to write
-            path: S3 path to write to
+            path: Resolved destination path
             write_options: Write options for the DataFrame (includes format, mode, compression, etc.)
+            iceberg: Whether this write targets the configured Iceberg catalog
+            iceberg_warehouse_path: Warehouse root used to derive the Iceberg table identifier
         """
         # Extract format and mode from write_options (create copy to avoid mutating original)
         options_copy = write_options.copy()
@@ -371,7 +406,17 @@ class S3Loader(BaseLoader):
         if options_copy:
             writer = writer.options(**options_copy)
 
-        writer.save(path)
+        # Iceberg catalog writes must use a catalog table identifier, not a filesystem path.
+        if iceberg:
+            if not iceberg_warehouse_path:
+                raise LoaderError("iceberg_warehouse_path must be provided for Iceberg writes")
+
+            table_identifier = self._get_iceberg_table_identifier(path, iceberg_warehouse_path)
+
+            # Use catalog-aware table writes so append/overwrite can create the table when missing.
+            writer.saveAsTable(table_identifier)
+        else:
+            writer.save(path)
 
     def _cleanup_temp_dir(self, store: SparkFilesystemObjectStore, temp_path: str) -> None:
         """
@@ -421,8 +466,8 @@ class S3Loader(BaseLoader):
     ) -> str:
         """
         Load data to S3 using Spark.
-        Handles both Spark DataFrames and lists of dictionaries.
-        Supports both Delta (directory-based) and Parquet (file-based) formats.
+        Handles both Spark DataFrames and lists of dictionaries as input, converting to DataFrame if necessary.
+        Supports both Delta (directory-based), Iceberg (directory-based) and Parquet (file-based) formats.
 
         Args:
             data: Input data (DataFrame or list of dicts)
@@ -472,9 +517,14 @@ class S3Loader(BaseLoader):
         df = self._ensure_dataframe(data, schema)
 
         # Branch based on format type
-        if config.format == "delta":
+        if config.format == LoadingFormat.DELTA:
             # Delta format: write directly to final directory location
             return self._load_delta(
+                df, config, base_uri=base_uri, source_type=source_type, **kwargs
+            )
+        elif config.format == LoadingFormat.ICEBERG:
+            # Iceberg format: write directly to final directory location
+            return self._load_iceberg(
                 df, config, base_uri=base_uri, source_type=source_type, **kwargs
             )
         else:
@@ -483,36 +533,43 @@ class S3Loader(BaseLoader):
                 df, config, base_uri=base_uri, source_type=source_type, **kwargs
             )
 
-    def _delta_table_exists(self, path: str) -> bool:
+    def _table_exists(self, path: str, table_format: LoadingFormat) -> bool:
         """
-        Check if a Delta table exists at the given path.
+        Check if a table exists at the given path for the requested table format.
 
-        Checks for the presence of the _delta_log directory, which is required
-        for a valid Delta table.
+        Validates the presence of the format-specific metadata directory:
+        - Delta: `_delta_log`
+        - Iceberg: `metadata`
 
         Args:
-            path: URI path to the Delta table
+            path: URI path to the table
+            table_format: Table format to validate
 
         Returns:
-            bool: True if Delta table exists, False otherwise
+            bool: True if the table exists, False otherwise
         """
-        try:
-            if DeltaTable is None:
-                self.logger.warning(
-                    "DeltaTable not available, cannot check if table exists",
-                    extra_fields={"path": path},
-                )
-                return False
+        metadata_directories = {
+            LoadingFormat.DELTA: "_delta_log",
+            LoadingFormat.ICEBERG: "metadata",
+        }
+        metadata_dir = metadata_directories.get(table_format)
 
+        if not metadata_dir:
+            return False
+
+        try:
             store = self.object_store
-            delta_log = store.resolve_path(path.rstrip("/"), "_delta_log")
-            return store.exists(delta_log)
+            metadata_path = store.resolve_path(path.rstrip("/"), metadata_dir)
+            return store.exists(metadata_path)
 
         except Exception as e:
-            # If any error occurs, assume table doesn't exist
             self.logger.trace(
-                "Error checking if Delta table exists, assuming it doesn't",
-                extra_fields={"path": path, "error": str(e)},
+                "Error checking if table exists, assuming it doesn't",
+                extra_fields={
+                    "path": path,
+                    "format": table_format.value,
+                    "error": str(e),
+                },
             )
             return False
 
@@ -522,7 +579,7 @@ class S3Loader(BaseLoader):
         source_type: Optional[str] = None,
     ) -> bool:
         """
-        Check if the Delta table destination already exists (for auto-backfill detection).
+        Check if the table destination already exists (for auto-backfill detection).
 
         Used to decide whether to run backfill on first write: when destination does
         not exist and backfill is configured, the pipeline uses backfill date ranges.
@@ -532,11 +589,14 @@ class S3Loader(BaseLoader):
             source_type: Optional source type to prepend to the path (e.g. rest_api).
 
         Returns:
-            True if the Delta table exists at the configured path, False otherwise.
-            Returns False if destination is not object-store backed, format is not delta,
-            or required path fields are missing.
+            True if the configured table exists at the resolved path, False otherwise.
+            Returns False if destination is not object-store backed, format is not a
+            table format, or required path fields are missing.
         """
-        if config.destination not in ("s3", "local") or config.format != "delta":
+        if config.destination not in ("s3", "local") or config.format not in [
+            LoadingFormat.DELTA,
+            LoadingFormat.ICEBERG,
+        ]:
             return False
         if config.destination == "s3" and (not config.bucket or not config.prefix):
             return False
@@ -552,12 +612,13 @@ class S3Loader(BaseLoader):
             )
         except ValueError:
             return False
-        path = self._generate_delta_path(
+
+        path = self._generate_table_path(
             base_uri=base_uri,
             prefix=config.prefix,
             source_type=source_type,
         )
-        return self._delta_table_exists(path)
+        return self._table_exists(path, config.format)
 
     def _perform_delta_merge(
         self, df: DataFrame, delta_path: str, merge_keys: List[str], config: LoadingConfig
@@ -688,9 +749,152 @@ class S3Loader(BaseLoader):
             )
             raise LoaderError(error_msg) from e
 
+    def _perform_iceberg_merge(
+        self,
+        df: DataFrame,
+        table_path: str,
+        merge_keys: List[str],
+        iceberg_warehouse_path: str,
+    ) -> None:
+        """
+        Perform an Iceberg MERGE INTO operation (upsert).
+
+        Matched rows update only columns present in both source and target, excluding
+        merge keys from the update set. Unmatched rows insert all target columns, with
+        typed NULLs for target-only columns.
+
+        Args:
+            df: Source DataFrame with data to merge
+            table_path: Filesystem path to the Iceberg table
+            merge_keys: List of column names to use as primary keys for matching
+            iceberg_warehouse_path: Warehouse root configured for the `iceberg` catalog
+
+        Raises:
+            LoaderError: If merge operation fails or merge keys are invalid
+        """
+        if not self.spark:
+            raise LoaderError("Spark session not set. Call set_spark_session first.")
+
+        df_columns_lower = {col.lower() for col in df.columns}
+        missing_keys = [key for key in merge_keys if key.lower() not in df_columns_lower]
+        if missing_keys:
+            raise LoaderError(
+                f"Merge keys not found in DataFrame: {missing_keys}. "
+                f"Available columns: {df.columns}"
+            )
+
+        table_identifier = self._get_iceberg_table_identifier(table_path, iceberg_warehouse_path)
+        source_view = f"iceberg_merge_source_{uuid.uuid4().hex}"
+
+        try:
+            target_df = self.spark.table(table_identifier)
+
+            source_cols_map = {col.lower(): col for col in df.columns}
+            target_cols_map = {col.lower(): col for col in target_df.columns}
+
+            missing_target_keys = [key for key in merge_keys if key.lower() not in target_cols_map]
+            if missing_target_keys:
+                raise LoaderError(
+                    f"Merge keys not found in Iceberg table: {missing_target_keys}. "
+                    f"Available columns: {target_df.columns}"
+                )
+
+            merge_conditions = [
+                f"target.`{target_cols_map[key.lower()]}` = source.`{source_cols_map[key.lower()]}`"
+                for key in merge_keys
+            ]
+
+            target_schema: Dict[str, Any] = {
+                field.name: field.dataType for field in target_df.schema.fields
+            }
+            target_columns: List[str] = list(target_schema.keys())
+            merge_keys_lower = {key.lower() for key in merge_keys}
+
+            update_assignments: List[str] = []
+            insert_columns: List[str] = []
+            insert_values: List[str] = []
+
+            for target_col in target_columns:
+                target_col_lower = target_col.lower()
+
+                # used in both update and insert, so add to insert columns regardless of source match
+                insert_columns.append(f"`{target_col}`")
+
+                # if a column in target is present in source (case-insensitive), we can update and insert from source; otherwise insert NULL
+                if target_col_lower in source_cols_map:
+                    source_col_exact = source_cols_map[target_col_lower]
+                    insert_values.append(f"source.`{source_col_exact}`")
+
+                    if target_col_lower not in merge_keys_lower:
+                        update_assignments.append(f"`{target_col}` = source.`{source_col_exact}`")
+                else:
+                    data_type = target_schema[target_col].simpleString()
+                    insert_values.append(f"CAST(NULL AS {data_type})")
+
+            df.createOrReplaceTempView(source_view)
+
+            merge_sql_lines = [
+                f"MERGE INTO {table_identifier} AS target",
+                f"USING {source_view} AS source",
+                f"ON {' AND '.join(merge_conditions)}",
+            ]
+
+            if update_assignments:
+                merge_sql_lines.append("WHEN MATCHED THEN UPDATE SET")
+                merge_sql_lines.append("  " + ", ".join(update_assignments))
+
+            merge_sql_lines.append(f"WHEN NOT MATCHED THEN INSERT ({', '.join(insert_columns)})")
+            merge_sql_lines.append(f"VALUES ({', '.join(insert_values)})")
+
+            merge_sql = "\n".join(merge_sql_lines)
+
+            self.logger.debug(
+                "Performing Iceberg MERGE operation",
+                extra_fields={
+                    "table_path": table_path,
+                    "table_identifier": table_identifier,
+                    "merge_keys": merge_keys,
+                    "merge_condition": " AND ".join(merge_conditions),
+                    "source_column_count": len(df.columns),
+                    "update_columns": update_assignments,
+                    "insert_columns": insert_columns,
+                },
+            )
+
+            self.spark.sql(merge_sql)
+
+            self.logger.info(
+                "Iceberg MERGE operation completed successfully",
+                extra_fields={
+                    "table_path": table_path,
+                    "table_identifier": table_identifier,
+                    "merge_keys": merge_keys,
+                },
+            )
+
+        except Exception as e:
+            error_msg = f"Failed to perform Iceberg MERGE operation: {e!s}"
+            self.logger.error(
+                error_msg,
+                extra_fields={
+                    "error": str(e),
+                    "table_path": table_path,
+                    "table_identifier": table_identifier,
+                    "merge_keys": merge_keys,
+                },
+            )
+            raise LoaderError(error_msg) from e
+        finally:
+            if self.spark:
+                try:
+                    self.spark.catalog.dropTempView(source_view)
+                except Exception:
+                    pass
+
     def _sanitize_column_names(self, df: DataFrame) -> DataFrame:
         """
-        Sanitize column names by handling illegal characters for Delta Lake.
+        Sanitize column names by handling illegal characters for table formats such as
+        Delta and Iceberg.
 
         Illegal characters are replaced/removed as follows:
         - Space ( ) -> underscore (_)
@@ -730,7 +934,7 @@ class S3Loader(BaseLoader):
             # Apply renames if any columns need sanitization
             if columns_to_rename:
                 self.logger.debug(
-                    "Sanitizing column names for Delta Lake",
+                    "Sanitizing column names for table writes",
                     extra_fields={"columns_renamed": columns_to_rename},
                 )
                 for old_name, new_name in columns_to_rename.items():
@@ -803,6 +1007,185 @@ class S3Loader(BaseLoader):
             )
             raise LoaderError(error_msg) from e
 
+    def _load_iceberg(
+        self,
+        df: DataFrame,
+        config: LoadingConfig,
+        *,
+        base_uri: str,
+        source_type: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Load data as an Iceberg table with support for append, overwrite, and merge.
+
+        Iceberg tables are stored as directories managed by the configured `iceberg`
+        catalog. Append and overwrite use catalog-aware writes. Merge uses SQL
+        `MERGE INTO` against the catalog table identifier derived from the resolved
+        table path.
+
+        Args:
+            df: DataFrame to write
+            config: Loading configuration (must include merge_keys for merge mode)
+            source_type: Optional source type to prepend to the path
+            **kwargs: Additional arguments for specific formats
+
+        Returns:
+            str: Iceberg table path
+
+        Raises:
+            LoaderError: If loading fails or configuration is invalid
+        """
+        try:
+            # Handle duplicate column names by renaming them to unique names
+            df = self._rename_duplicate_columns(df)
+
+            self.logger.trace(
+                "DataFrame after handling duplicate columns",
+                extra_fields={"columns": df.columns},
+            )
+
+            # Sanitize column names before writing table-backed formats
+            df = self._sanitize_column_names(df)
+
+            self.logger.trace(
+                "DataFrame after sanitizing column names",
+                extra_fields={"columns": df.columns},
+            )
+
+            # Force deduplicate on merge keys if configured to avoid non-deterministic
+            # upserts when the source contains duplicate keys.
+            if config.force_nondeterministic_deduplication and config.write_mode == "merge":
+                self.logger.warning("Forcing non-deterministic deduplication...")
+
+                df = df.dropDuplicates(config.merge_keys)
+
+                self.logger.info(f"Source rows after deduplication: {df.count()}")
+
+            # Generate Iceberg table path (directory-based)
+            final_path = self._generate_table_path(
+                base_uri=base_uri, prefix=config.prefix, source_type=source_type
+            )
+
+            self.logger.trace(
+                "Writing Iceberg table",
+                extra_fields={
+                    "table_path": final_path,
+                    "write_mode": config.write_mode,
+                    "has_merge_keys": config.merge_keys is not None,
+                },
+            )
+
+            # Register the Iceberg catalog warehouse root for this write so the derived
+            # catalog table identifier resolves to the same filesystem location as final_path.
+            if self.spark:
+                self.spark.conf.set("spark.sql.catalog.iceberg.warehouse", base_uri.rstrip("/"))
+
+            if config.write_mode == "merge":
+                if config.merge_keys is None:
+                    raise LoaderError("merge_keys must be provided when write_mode is 'merge'")
+
+                # First write creates the table using append semantics. Subsequent writes
+                # use Iceberg MERGE INTO for upsert behavior.
+                if not self._table_exists(final_path, LoadingFormat.ICEBERG):
+                    self.logger.debug(
+                        "Iceberg table does not exist, creating it first",
+                        extra_fields={"table_path": final_path},
+                    )
+                    write_options = {
+                        "format": LoadingFormat.ICEBERG,
+                        "mode": "append",
+                        "mergeSchema": "true",
+                        **kwargs.get("write_options", {}),
+                    }
+                    if config.compression:
+                        write_options["compression"] = config.compression
+
+                    self._write_dataframe(
+                        df,
+                        final_path,
+                        write_options,
+                        iceberg=True,
+                        iceberg_warehouse_path=base_uri,
+                    )
+                else:
+                    self._perform_iceberg_merge(
+                        df,
+                        final_path,
+                        config.merge_keys,
+                        base_uri,
+                    )
+
+            elif config.write_mode == "append":
+                write_options = {
+                    "format": LoadingFormat.ICEBERG,
+                    "mode": "append",
+                    "mergeSchema": "true",
+                    **kwargs.get("write_options", {}),
+                }
+                if config.compression:
+                    write_options["compression"] = config.compression
+
+                self._write_dataframe(
+                    df,
+                    final_path,
+                    write_options,
+                    iceberg=True,
+                    iceberg_warehouse_path=base_uri,
+                )
+
+            else:
+                write_options = {
+                    "format": LoadingFormat.ICEBERG,
+                    "mode": config.write_mode,
+                    "mergeSchema": "true",
+                    **kwargs.get("write_options", {}),
+                }
+                if config.compression:
+                    write_options["compression"] = config.compression
+
+                self._write_dataframe(
+                    df,
+                    final_path,
+                    write_options,
+                    iceberg=True,
+                    iceberg_warehouse_path=base_uri,
+                )
+
+            self.logger.info(
+                "Successfully loaded Iceberg table",
+                extra_fields={
+                    "destination": final_path,
+                    "write_mode": config.write_mode,
+                    "merge_keys": config.merge_keys if config.write_mode == "merge" else None,
+                },
+            )
+
+            return final_path
+
+        except Exception as e:
+            error_msg = f"Failed to load Iceberg table: {e!s}"
+            self.logger.error(
+                error_msg,
+                extra_fields={
+                    "error": str(e),
+                    "destination": config.destination,
+                    "prefix": config.prefix,
+                    "write_mode": config.write_mode,
+                },
+            )
+            raise LoaderError(error_msg) from e
+        finally:
+            # Clean up the warehouse path from Spark configuration to avoid side effects on other operations
+            if self.spark:
+                try:
+                    self.spark.conf.unset("spark.sql.catalog.iceberg.warehouse")
+                except Exception as e:
+                    self.logger.trace(
+                        "Failed to unset Iceberg warehouse configuration after write",
+                        extra_fields={"error": str(e), "warehouse": base_uri.rstrip("/")},
+                    )
+
     def _load_delta(
         self,
         df: DataFrame,
@@ -851,10 +1234,17 @@ class S3Loader(BaseLoader):
                 extra_fields={"columns": df.columns},
             )
 
-            # Generate Delta table path (directory-based)
-            # For Delta, we use the prefix directly without "data/" suffix
+            # Force deduplicate on merge keys if configured, to avoid non-deterministic merge failures due to duplicate keys in source data. This is a temporary workaround until we implement proper merge logic for Delta that can handle duplicates without failure.
+            if config.force_nondeterministic_deduplication and config.write_mode == "merge":
+                self.logger.warning("Forcing non-deterministic deduplication...")
+
+                df = df.dropDuplicates(config.merge_keys)
+
+                self.logger.info(f"Source rows after deduplication: {df.count()}")
+
+            # Generate table path (directory-based)
             # Source type prefix is automatically prepended
-            final_path = self._generate_delta_path(
+            final_path = self._generate_table_path(
                 base_uri=base_uri, prefix=config.prefix, source_type=source_type
             )
 
@@ -867,18 +1257,11 @@ class S3Loader(BaseLoader):
                 },
             )
 
-            if config.force_nondeterministic_deduplication and config.write_mode == "merge":
-                self.logger.warning("Forcing non-deterministic deduplication...")
-
-                df = df.dropDuplicates(config.merge_keys)
-
-                self.logger.info(f"Source rows after deduplication: {df.count()}")
-
             # Handle different write modes
             if config.write_mode == "merge":
                 # Merge mode: Use Delta Lake MERGE operation for upsert
                 # Check if table exists - if not, create it first using append mode
-                if not self._delta_table_exists(final_path):
+                if not self._table_exists(final_path, LoadingFormat.DELTA):
                     self.logger.debug(
                         "Delta table does not exist, creating it first",
                         extra_fields={"delta_path": final_path},
@@ -886,7 +1269,7 @@ class S3Loader(BaseLoader):
                     # Create table using append mode (first write)
                     # This ensures schema evolution is enabled
                     write_options = {
-                        "format": "delta",
+                        "format": LoadingFormat.DELTA,
                         "mode": "append",
                         "mergeSchema": "true",  # Enable schema evolution
                     }
@@ -904,7 +1287,7 @@ class S3Loader(BaseLoader):
                 # Append mode: Add new data without removing existing data
                 # Schema evolution is enabled to allow new columns
                 write_options = {
-                    "format": "delta",
+                    "format": LoadingFormat.DELTA,
                     "mode": "append",
                     "mergeSchema": "true",  # Enable schema evolution
                     **kwargs.get("write_options", {}),
@@ -921,7 +1304,7 @@ class S3Loader(BaseLoader):
                 # Overwrite mode (default) or other modes: Use standard write
                 # Schema evolution is enabled to allow new columns
                 write_options = {
-                    "format": "delta",
+                    "format": LoadingFormat.DELTA,
                     "mode": config.write_mode,
                     "mergeSchema": "true",  # Enable schema evolution
                     **kwargs.get("write_options", {}),


### PR DESCRIPTION
Resolves #15 

## Summary

<!-- What does this PR change and why? -->

- Add Iceberg loading support to Spark and S3 loader
- Introduce a typed loading format enum, register Iceberg Spark
  packages and catalog settings, and extend the S3 loader to detect,
  resolve, and write Iceberg tables alongside Delta.
- Add example usage `jsonplaceholder.iceberg.append.yml`
- Add documentation pertaining to this feature at `docs/configuration/loading.md`
- Important thing to note:
  - Usage of `org.apache.iceberg.spark.SparkCatalog` vs `org.apache.iceberg.spark.SparkSessionCatalog` for setting up custom `iceberg` catalog in spark configurations: https://iceberg.apache.org/docs/latest/spark-configuration/#catalog-configuration 

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.