### PR TITLE
Chore/early validation configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,11 +37,17 @@ env/
 venv/
 ENV/
 
-# IDE
+# IDE / AI assistants
 .idea/
 .vscode/
 .cursor/
 .kiro/
+.claude/
+.windsurf/
+.github/copilot/
+.codeium/
+.continue/
+.aider*
 *.swp
 *.swo
 

--- a/src/config/backfill_config.py
+++ b/src/config/backfill_config.py
@@ -30,6 +30,9 @@ class BackfillStaticDateConfig:
         False  # if False, windows contiguous (next_start=endDate+1); if True, boundary overlaps (next_start=endDate)
     )
 
+    def __post_init__(self) -> None:
+        self.increment = str(self.increment).strip().upper()
+
 
 @dataclass
 class BackfillReferenceConfig:
@@ -38,6 +41,10 @@ class BackfillReferenceConfig:
     field: str  # request input name of the driver (e.g. startDate)
     increment: str  # e.g. '15 DAY'
     limit: Any  # str or dict for dynamic (e.g. type: DATE, operation: TODAY)
+
+    def __post_init__(self) -> None:
+        self.field = str(self.field).strip()
+        self.increment = str(self.increment).strip().upper()
 
 
 @dataclass
@@ -66,7 +73,7 @@ def parse_increment(increment_str: str) -> relativedelta:
     """
     if not increment_str or not isinstance(increment_str, str):
         raise ValueError("increment must be a non-empty string")
-    parts = increment_str.strip().upper().split()
+    parts = increment_str.upper().split()
     if len(parts) != 2:
         raise ValueError(
             f"increment must be of form 'N DAY', 'N WEEK', or 'N MONTH', got: {increment_str!r}"
@@ -118,7 +125,7 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
         backfill = value.get("backfill")
         if not isinstance(backfill, dict):
             continue
-        bf_type = (backfill.get("type") or "").strip().upper()
+        bf_type = (backfill.get("type") or "").upper()
         if bf_type == BACKFILL_TYPE_STATIC_DATE:
             start = backfill.get("start")
             end = backfill.get("end")
@@ -130,7 +137,7 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
                 candidate_driver = BackfillStaticDateConfig(
                     start=start,
                     end=end,
-                    increment=str(increment).strip(),
+                    increment=increment,
                     inclusive=bool(inclusive),
                 )
                 parse_increment(candidate_driver.increment)
@@ -153,8 +160,8 @@ def get_backfill_config(input_values: Optional[Dict[str, Any]]) -> Optional[Back
                 continue
             try:
                 candidate_reference = BackfillReferenceConfig(
-                    field=str(ref_field).strip(),
-                    increment=str(ref_increment).strip(),
+                    field=ref_field,
+                    increment=ref_increment,
                     limit=limit,
                 )
                 parse_increment(candidate_reference.increment)

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -1015,6 +1015,15 @@ class ResourceConfig(BaseModel):
         default=None,
         description="Database table or view name for extract (required for database source types on this resource).",
     )
+
+    @field_validator("database_schema", "database_table", mode="before")
+    @classmethod
+    def strip_db_table_identifier(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        stripped = str(v).strip()
+        return stripped if stripped else None
+
     database_select_query: Optional[str] = Field(
         default=None,
         description="Optional full SQL query for extract; when set, schema/table may still be used for logging.",
@@ -1300,9 +1309,7 @@ class SourceConfig(BaseModel):
             for resource_name, resource in self.resources.items():
                 if not resource.enabled:
                     continue
-                sch = (resource.database_schema or "").strip()
-                tbl = (resource.database_table or "").strip()
-                if not sch or not tbl:
+                if not resource.database_schema or not resource.database_table:
                     raise ValueError(
                         f"{self.type.value} resource '{resource_name}' requires non-empty "
                         "database_schema and database_table"

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -269,6 +269,37 @@ class LoadingConfig(BaseModel):
                 raise ValueError("azure_account is required for Azure destination")
         return self
 
+    def destination_dedup_key(self) -> tuple[str, ...]:
+        """Stable identity for a destination so the same bucket/root is probed once."""
+        if self.destination == "s3":
+            return ("s3", self.s3_bucket or "")
+        if self.destination == "gcs":
+            return ("gcs", self.gcs_bucket or "")
+        if self.destination == "azure_blob":
+            return ("azure_blob", self.azure_container or "", self.azure_account or "")
+        if self.destination == "local":
+            root = self.storage_root or ""
+            if not root:
+                return ("local", "")
+            return ("local", str(Path(root).expanduser().resolve()))
+        return (self.destination,)
+
+    def destination_details(self) -> Dict[str, Any]:
+        """Operator-readable destination context for errors and logs."""
+        if self.destination == "s3":
+            return {"destination": "s3", "s3_bucket": self.s3_bucket}
+        if self.destination == "gcs":
+            return {"destination": "gcs", "gcs_bucket": self.gcs_bucket}
+        if self.destination == "azure_blob":
+            return {
+                "destination": "azure_blob",
+                "azure_container": self.azure_container,
+                "azure_account": self.azure_account,
+            }
+        if self.destination == "local":
+            return {"destination": "local", "storage_root": self.storage_root}
+        return {"destination": self.destination}
+
     model_config = {"validate_assignment": True}
 
 
@@ -848,6 +879,15 @@ class TableReadOptions(BaseModel):
         default=None,
         description="Numeric (or date-castable) column for Spark parallel range reads.",
     )
+
+    @field_validator("partition_column", mode="before")
+    @classmethod
+    def normalize_partition_column(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        stripped = str(v).strip()
+        return stripped if stripped else None
+
     lower_bound: Optional[Union[int, float]] = Field(
         default=None,
         description="Inclusive lower bound for partition_column (operator-supplied).",
@@ -878,8 +918,7 @@ class TableReadOptions(BaseModel):
         """True when Spark will use column range or predicate-based JDBC partitioning for this resource."""
         if self.predicates is not None and len(self.predicates) > 0:
             return True
-        col = (self.partition_column or "").strip()
-        return bool(col)
+        return bool(self.partition_column)
 
     @model_validator(mode="after")
     def validate_partitioning(self) -> "TableReadOptions":
@@ -887,8 +926,7 @@ class TableReadOptions(BaseModel):
             raise ValueError("table_read_options.predicates must be non-empty when set")
 
         has_pred = self.predicates is not None and len(self.predicates) > 0
-        col = (self.partition_column or "").strip()
-        has_range = bool(col)
+        has_range = bool(self.partition_column)
 
         if has_pred and has_range:
             raise ValueError(
@@ -1220,6 +1258,14 @@ class SourceConfig(BaseModel):
         description="Extra JDBC properties or URL query parameters (driver-specific).",
     )
 
+    @field_validator("host", "username", "database", mode="before")
+    @classmethod
+    def strip_db_identifier(cls, v: object) -> Optional[str]:
+        if v is None:
+            return None
+        stripped = str(v).strip()
+        return stripped if stripped else None
+
     @model_validator(mode="after")
     def normalize_rest_base_url(self) -> "SourceConfig":
         """Strip trailing slashes from REST base URLs so path joins stay consistent."""
@@ -1249,7 +1295,7 @@ class SourceConfig(BaseModel):
                 raise ValueError(f"{self.type.value} source requires port")
             if not self.username or self.password is None:
                 raise ValueError(f"{self.type.value} source requires username and password")
-            if self.type == SourceType.POSTGRESQL and not (self.database or "").strip():
+            if self.type == SourceType.POSTGRESQL and not self.database:
                 raise ValueError(f"{self.type.value} source requires database")
             for resource_name, resource in self.resources.items():
                 if not resource.enabled:

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -1847,8 +1847,8 @@ class DynamicHandler(BaseHandler):
         """
         resource_config = resource_meta.config
         configured_fields = resource_config.fields
-        schema = str(resource_config.database_schema).strip()
-        table = str(resource_config.database_table).strip()
+        schema = resource_config.database_schema
+        table = resource_config.database_table
         request_context_count = len(request_contexts)
         extract_invocations = 0
         service.connect()

--- a/src/loader/base_loader.py
+++ b/src/loader/base_loader.py
@@ -2,175 +2,19 @@
 Base loader class providing common loading functionality.
 """
 
-import uuid
 from abc import ABC, abstractmethod
-from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from src.utils.datetime_utils import format_datetime
-from src.utils.exceptions import LoaderError
 from src.utils.logger import get_logger
 
 
 class BaseLoader(ABC):
-    """
-    Abstract base class for data loaders.
-    Provides common functionality for loading data into destinations.
-    """
+    """Abstract base class for data loaders."""
 
     def __init__(self):
-        """Initialize the loader."""
         self.logger = get_logger(self.__class__.__name__)
 
     @abstractmethod
     def load(self, data: List[Dict[str, Any]], destination: str, **kwargs) -> None:
-        """
-        Load data into the specified destination.
-        Must be implemented by concrete classes.
-
-        Args:
-            data: List of records to load
-            destination: Destination to load data into
-            **kwargs: Additional arguments for the loader
-
-        Raises:
-            LoaderError: If loading fails
-        """
+        """Load data into the specified destination."""
         pass
-
-    def _generate_destination_key(
-        self,
-        prefix: str,
-        extension: str = "",
-        include_timestamp: bool = True,
-        include_uuid: bool = False,
-    ) -> str:
-        """
-        Generate a unique destination key with UTC timestamp and optional UUID.
-
-        Args:
-            prefix: The prefix for the key
-            extension: Optional file extension (with dot)
-            include_timestamp: Whether to include timestamp in the key
-            include_uuid: Whether to include a UUID in the key
-
-        Returns:
-            str: Generated key in the format prefix/YYYY-MM-DDThh-mm-ssZ[_uuid][.extension]
-        """
-        # Clean prefix
-        clean_prefix = self._clean_path(prefix or "data")
-
-        # Generate components
-        components = [clean_prefix]
-
-        if include_timestamp:
-            timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
-            components.append(timestamp)
-
-        if include_uuid:
-            unique_id = str(uuid.uuid4())
-            components.append(unique_id)
-
-        # Join components
-        key = "/".join([components[0], "_".join(components[1:])])
-
-        # Add extension if provided
-        if extension:
-            if not extension.startswith("."):
-                extension = f".{extension}"
-            key = f"{key}{extension}"
-
-        return key
-
-    def _clean_path(self, path: str) -> str:
-        """
-        Clean a path by removing leading/trailing slashes and spaces.
-
-        Args:
-            path: Path to clean
-
-        Returns:
-            str: Cleaned path
-        """
-        return path.strip("/").strip()
-
-    def validate_data(
-        self, data: List[Dict[str, Any]], required_fields: Optional[List[str]] = None
-    ) -> None:
-        """
-        Validate data before loading.
-
-        Args:
-            data: Data to validate
-            required_fields: Optional list of required fields
-
-        Raises:
-            LoaderError: If validation fails
-        """
-        if not data:
-            raise LoaderError(message="No data provided for loading", operation="validate_data")
-
-        if not all(isinstance(record, dict) for record in data):
-            raise LoaderError(
-                message="All records must be dictionaries",
-                operation="validate_data",
-                details={
-                    "invalid_records": [
-                        i for i, record in enumerate(data) if not isinstance(record, dict)
-                    ]
-                },
-            )
-
-        if required_fields:
-            missing_fields = {}
-            for i, record in enumerate(data):
-                missing = [
-                    field
-                    for field in required_fields
-                    if field not in record or record[field] is None
-                ]
-                if missing:
-                    missing_fields[i] = missing
-
-            if missing_fields:
-                raise LoaderError(
-                    message="Records missing required fields",
-                    operation="validate_data",
-                    details={"missing_fields": missing_fields},
-                )
-
-    def validate_destination(self, destination: str) -> None:
-        """
-        Validate the destination exists and is accessible.
-
-        Args:
-            destination: Destination to validate
-
-        Raises:
-            LoaderError: If destination validation fails
-        """
-        if not destination:
-            raise LoaderError(message="No destination provided", operation="validate_destination")
-
-    def format_timestamp(self, dt: datetime) -> str:
-        """
-        Format a datetime object for loading.
-
-        Args:
-            dt: Datetime to format
-
-        Returns:
-            str: Formatted datetime string
-
-        Raises:
-            LoaderError: If datetime formatting fails
-        """
-        try:
-            return format_datetime(dt)
-        except ValueError as e:
-            raise LoaderError(
-                message="Failed to format datetime",
-                operation="format_timestamp",
-                details={"datetime": str(dt)},
-                original_error=e,
-            ) from e

--- a/src/loader/destination_preflight.py
+++ b/src/loader/destination_preflight.py
@@ -61,45 +61,6 @@ _AZURE_ACCOUNT_RE = re.compile(r"^[a-z0-9]{3,24}$")
 _AZURE_CONTAINER_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$")
 
 
-def _destination_dedup_key(config: LoadingConfig) -> Tuple[str, ...]:
-    """Stable identity for a destination so the same bucket/root is probed once."""
-    if config.destination == "s3":
-        return ("s3", config.s3_bucket or "")
-    if config.destination == "gcs":
-        return ("gcs", config.gcs_bucket or "")
-    if config.destination == "azure_blob":
-        return (
-            "azure_blob",
-            config.azure_container or "",
-            config.azure_account or "",
-        )
-    if config.destination == "local":
-        # Resolve to absolute so two different relative spellings of the same root
-        # are recognized as one destination.
-        root = config.storage_root or ""
-        if not root:
-            return ("local", "")
-        return ("local", str(Path(root).expanduser().resolve()))
-    return (config.destination,)
-
-
-def _destination_details(config: LoadingConfig) -> Dict[str, Any]:
-    """Operator-readable destination context attached to errors and logs."""
-    if config.destination == "s3":
-        return {"destination": "s3", "s3_bucket": config.s3_bucket}
-    if config.destination == "gcs":
-        return {"destination": "gcs", "gcs_bucket": config.gcs_bucket}
-    if config.destination == "azure_blob":
-        return {
-            "destination": "azure_blob",
-            "azure_container": config.azure_container,
-            "azure_account": config.azure_account,
-        }
-    if config.destination == "local":
-        return {"destination": "local", "storage_root": config.storage_root}
-    return {"destination": config.destination}
-
-
 def _s3_bucket_name_issue(name: str) -> Optional[str]:
     """Return a human-readable issue or ``None`` if the name is plausibly valid."""
     if len(name) < 3 or len(name) > 63:
@@ -355,7 +316,7 @@ def _probe_local(config: LoadingConfig) -> None:
     if not config.storage_root:
         raise HandlerError(
             "storage_root is required for local destination preflight",
-            details=_destination_details(config),
+            details=config.destination_details(),
         )
     check_local_storage_root(Path(config.storage_root))
 
@@ -373,7 +334,7 @@ def _probe_object_store(
     with the destination scheme and bucket/container in ``details``.
     """
     store = SparkFilesystemObjectStore(spark)
-    details = _destination_details(config)
+    details = config.destination_details()
     details["base_uri"] = base_uri
     fs_timeout_seconds = _filesystem_timeout_seconds()
 
@@ -508,7 +469,7 @@ def preflight_destinations(
             continue
         if config.destination not in OBJECT_STORE_DESTINATIONS:
             continue
-        key = _destination_dedup_key(config)
+        key = config.destination_dedup_key()
         if key in seen:
             continue
         seen.add(key)
@@ -518,7 +479,7 @@ def preflight_destinations(
         return
 
     for config in deduped:
-        details = _destination_details(config)
+        details = config.destination_details()
         _logger.debug(
             "Running destination preflight",
             extra_fields={**details, "write_probe": write_probe},

--- a/src/loader/loader_factory.py
+++ b/src/loader/loader_factory.py
@@ -5,8 +5,9 @@ Factory for creating loader instances based on configuration.
 from typing import ClassVar, Dict, Type
 
 from src.config.config_models import LoadingConfig
-from src.loader.base_loader import BaseLoader, LoaderError
+from src.loader.base_loader import BaseLoader
 from src.loader.object_store_loader import ObjectStoreLoader
+from src.utils.exceptions import LoaderError
 
 
 class LoaderFactory:

--- a/src/loader/object_store_loader.py
+++ b/src/loader/object_store_loader.py
@@ -14,8 +14,9 @@ from pyspark.sql.types import StructField, StructType
 
 from src.config.config_models import LoadingConfig, LoadingFormat
 from src.config.loading_schema import OBJECT_STORE_DESTINATIONS
-from src.loader.base_loader import BaseLoader, LoaderError
+from src.loader.base_loader import BaseLoader
 from src.loader.object_store import SparkFilesystemObjectStore, loading_base_uri
+from src.utils.exceptions import LoaderError
 from src.utils.logger import get_logger
 
 # Common transient I/O error substrings across S3, GCS, and Azure storage drivers.

--- a/src/service/hana_service.py
+++ b/src/service/hana_service.py
@@ -1,5 +1,6 @@
 """SAP HANA ingestion via Spark JDBC (SAP ngdbc driver)."""
 
+from functools import cached_property
 from typing import Optional
 from urllib.parse import quote_plus
 
@@ -65,7 +66,7 @@ class HanaService(SqlDatabaseService):
         select_query: Optional[str],
         table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
-        jdbc_url = self._build_jdbc_url()
+        jdbc_url = self._jdbc_url
         table_ref = self._quoted_from_clause(schema, table)
 
         if select_query:
@@ -73,16 +74,9 @@ class HanaService(SqlDatabaseService):
         else:
             query = f"(SELECT * FROM {table_ref}) AS data_query"
 
-        connection_properties: dict[str, str] = {
-            "driver": self.HANA_JDBC_DRIVER,
-            "user": self.config.username or "",
-            "password": self.config.password or "",
-        }
-        if self.config.connection_params:
-            for k, v in self.config.connection_params.items():
-                connection_properties[str(k)] = str(v)
-        if table_read_options is not None and table_read_options.fetch_size is not None:
-            connection_properties["fetchsize"] = str(table_read_options.fetch_size)
+        connection_properties = self._build_connection_properties(
+            self.HANA_JDBC_DRIVER, table_read_options
+        )
 
         reader = spark_session.read
         if table_read_options is not None and table_read_options.predicates:
@@ -92,12 +86,11 @@ class HanaService(SqlDatabaseService):
                 predicates=table_read_options.predicates,
                 properties=connection_properties,
             )
-        if table_read_options is not None and (table_read_options.partition_column or "").strip():
-            col = table_read_options.partition_column.strip()
+        if table_read_options is not None and table_read_options.partition_column:
             return reader.jdbc(
                 url=jdbc_url,
                 table=query,
-                column=col,
+                column=table_read_options.partition_column,
                 lowerBound=table_read_options.lower_bound,
                 upperBound=table_read_options.upper_bound,
                 numPartitions=table_read_options.num_partitions,
@@ -109,13 +102,13 @@ class HanaService(SqlDatabaseService):
             properties=connection_properties,
         )
 
-    def _build_jdbc_url(self) -> str:
+    @cached_property
+    def _jdbc_url(self) -> str:
         port = int(self.config.port)  # type: ignore[arg-type]
         base = f"jdbc:sap://{self.config.host}:{port}/"
         parts: list[str] = []
-        db = (self.config.database or "").strip()
-        if db:
-            parts.append(f"databaseName={quote_plus(db)}")
+        if self.config.database:
+            parts.append(f"databaseName={quote_plus(self.config.database)}")
         if self.config.connection_params:
             for k, v in self.config.connection_params.items():
                 key = str(k)

--- a/src/service/postgres_service.py
+++ b/src/service/postgres_service.py
@@ -1,5 +1,6 @@
 """PostgreSQL ingestion via Spark JDBC."""
 
+from functools import cached_property
 from typing import Optional
 
 from pyspark.sql import DataFrame, SparkSession
@@ -66,7 +67,7 @@ class PostgresService(SqlDatabaseService):
         select_query: Optional[str],
         table_read_options: Optional[TableReadOptions] = None,
     ) -> DataFrame:
-        jdbc_url = self._build_jdbc_url()
+        jdbc_url = self._jdbc_url
         table_ref = self._table_label_for_log(schema, table)
 
         if select_query:
@@ -74,16 +75,9 @@ class PostgresService(SqlDatabaseService):
         else:
             query = f"(SELECT * FROM {table_ref}) AS data_query"
 
-        connection_properties: dict[str, str] = {
-            "driver": self.POSTGRES_JDBC_DRIVER,
-            "user": self.config.username or "",
-            "password": self.config.password or "",
-        }
-        if self.config.connection_params:
-            for k, v in self.config.connection_params.items():
-                connection_properties[str(k)] = str(v)
-        if table_read_options is not None and table_read_options.fetch_size is not None:
-            connection_properties["fetchsize"] = str(table_read_options.fetch_size)
+        connection_properties = self._build_connection_properties(
+            self.POSTGRES_JDBC_DRIVER, table_read_options
+        )
 
         reader = spark_session.read
         if table_read_options is not None and table_read_options.predicates:
@@ -93,12 +87,11 @@ class PostgresService(SqlDatabaseService):
                 predicates=table_read_options.predicates,
                 properties=connection_properties,
             )
-        if table_read_options is not None and (table_read_options.partition_column or "").strip():
-            col = table_read_options.partition_column.strip()
+        if table_read_options is not None and table_read_options.partition_column:
             return reader.jdbc(
                 url=jdbc_url,
                 table=query,
-                column=col,
+                column=table_read_options.partition_column,
                 lowerBound=table_read_options.lower_bound,
                 upperBound=table_read_options.upper_bound,
                 numPartitions=table_read_options.num_partitions,
@@ -110,9 +103,10 @@ class PostgresService(SqlDatabaseService):
             properties=connection_properties,
         )
 
-    def _build_jdbc_url(self) -> str:
+    @cached_property
+    def _jdbc_url(self) -> str:
         port = int(self.config.port)  # type: ignore[arg-type]
-        base_url = f"jdbc:postgresql://{self.config.host}:{port}/" f"{self.config.database}"
+        base_url = f"jdbc:postgresql://{self.config.host}:{port}/{self.config.database}"
         if self.config.connection_params:
             url_params = {
                 k: v

--- a/src/service/sql_database_service.py
+++ b/src/service/sql_database_service.py
@@ -108,6 +108,23 @@ class SqlDatabaseService(BaseSourceService, ABC):
         self._validate_host_for_connect()
         self._validate_port_for_connect()
 
+    def _build_connection_properties(
+        self,
+        driver: str,
+        table_read_options: Optional[TableReadOptions] = None,
+    ) -> Dict[str, str]:
+        props: Dict[str, str] = {
+            "driver": driver,
+            "user": self.config.username or "",
+            "password": self.config.password or "",
+        }
+        if self.config.connection_params:
+            for k, v in self.config.connection_params.items():
+                props[str(k)] = str(v)
+        if table_read_options is not None and table_read_options.fetch_size is not None:
+            props["fetchsize"] = str(table_read_options.fetch_size)
+        return props
+
     def _ensure_extract_prerequisites(self) -> None:
         """Override when extract needs an established client (e.g. SQLAlchemy engine)."""
 
@@ -163,8 +180,8 @@ class SqlDatabaseService(BaseSourceService, ABC):
                     extra_log["fetch_size"] = table_read_options.fetch_size
                 if table_read_options.predicates:
                     extra_log["predicates_count"] = len(table_read_options.predicates)
-                if (table_read_options.partition_column or "").strip():
-                    extra_log["partition_column"] = table_read_options.partition_column.strip()
+                if table_read_options.partition_column:
+                    extra_log["partition_column"] = table_read_options.partition_column
                     extra_log["num_partitions"] = table_read_options.num_partitions
 
             defaults = self.settings.pipeline_config.defaults


### PR DESCRIPTION
## Summary

Push string normalization and config validation earlier into the load lifecycle — at Pydantic construction time rather than scattered across runtime functions.

- `TableReadOptions.partition_column` — field validator strips/normalizes at load time; removes 5 duplicate `(x or "").strip()` call sites
- `SourceConfig` (`host`, `username`, `database`) and `ResourceConfig` (`database_schema`, `database_table`) — field validators strip at load time; simplifies callers in handler and source validator
- `LoadingConfig.destination_dedup_key()` / `destination_details()` — moved from repeated dispatch chains in `destination_preflight.py` onto the config object itself
- `SqlDatabaseService._build_connection_properties()` — extracted identical connection-dict assembly from Postgres and HANA into a shared base method
- `_jdbc_url` as `@cached_property` — JDBC URL was rebuilt from static config on every read
- `BackfillStaticDateConfig` / `BackfillReferenceConfig` — `__post_init__` normalizes `increment` and `field`; `get_backfill_config` passes raw values
- `BaseLoader` — deleted five methods (`_clean_path`, `_generate_destination_key`, `validate_data`, `validate_destination`, `format_timestamp`) that were never called outside the file

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
