### PR TITLE
feat: rate limiting

### DIFF
--- a/config/defaults.example.yml
+++ b/config/defaults.example.yml
@@ -5,6 +5,11 @@ defaults:
     max_attempts: 3
     initial_delay: 1
     backoff_factor: 2
+    # HTTP transport (urllib3): honor Retry-After on 429/503/413; cap parsed delay and backoff.
+    honor_retry_after_header: true
+    max_retry_after_seconds: 21600
+    max_backoff_seconds: 120
+    backoff_jitter_seconds: 0
 
   # Default is false, when true, run Spark df.count() for exact row totals in logs and summaries (full scan).
   log_full_row_count: false

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -38,6 +38,11 @@ defaults:
     max_attempts: 3
     initial_delay: 1
     backoff_factor: 2
+    # HTTP client (urllib3): Retry-After on 429/503/413, capped by max_retry_after_seconds.
+    honor_retry_after_header: true
+    max_retry_after_seconds: 21600
+    max_backoff_seconds: 120
+    backoff_jitter_seconds: 0
   loading:
     destination: "s3"
     format: "delta"
@@ -90,6 +95,12 @@ Future JDBC-backed sources (for example MySQL or Redshift) can reuse this block 
 - **`defaults.loading`** is merged into every resource that does not define its own `loading` block (and `loading: null` in YAML is treated the same as omitted: inherit defaults). For object-store destinations (**`local`**, **`s3`**, **`gcs`**, **`azure_blob`**), if **`prefix`** is omitted, the handler sets **`{source_name}/{resource_name}`** before writing.
 - **`loading.enabled`**: after merging defaults, set **`enabled: false`** on a resource to skip loader writes for that resource only.
 - **`defaults.log_full_row_count`**: when **`true`**, the handler runs a full Spark **`df.count()`** for result summaries and enables the same global behavior for database extracts unless a resource opts in with **`table_read_options.log_exact_row_count`**. When **`false`** (default), the handler uses a lightweight non-empty check instead of a full count, and database extracts skip **`df.count()`** unless **`table_read_options.log_exact_row_count`** is **`true`** for that resource.
+
+### Retry budget and HTTP transport (REST)
+
+- **`max_attempts`**, **`initial_delay`**, and **`backoff_factor`** still describe the overall retry budget surfaced to **`APISettings`** (including **`RestService`** auth backoff).
+- **`honor_retry_after_header`**, **`max_retry_after_seconds`**, **`max_backoff_seconds`**, and **`backoff_jitter_seconds`** configure urllib3 `Retry` on the shared **`requests.Session`**: when **`honor_retry_after_header`** is true, the client sleeps per **`Retry-After`** on responses urllib3 retries (including **429**, **503**, and **413**), with **`Retry-After`** capped by **`max_retry_after_seconds`**. Exponential backoff between attempts is capped by **`max_backoff_seconds`**; **`backoff_jitter_seconds`** adds random delay on that backoff path only (urllib3 behavior).
+- Turning on **`Retry-After`** can increase wall-clock time per call versus ignoring it; **`max_attempts`** defaults are unchanged.
 
 ### Database resources and request contexts
 

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -46,6 +46,28 @@ class RetryConfig(BaseModel):
     max_attempts: int = Field(default=3, ge=1)
     initial_delay: float = Field(default=1.0, gt=0)
     backoff_factor: float = Field(default=2.0, gt=1)
+    honor_retry_after_header: bool = Field(
+        default=True,
+        description=(
+            "When true, urllib3 honors Retry-After on responses it retries "
+            "(429, 503, 413 per urllib3), capped by max_retry_after_seconds."
+        ),
+    )
+    max_retry_after_seconds: int = Field(
+        default=21600,
+        ge=1,
+        description="Maximum parsed Retry-After delay in seconds (matches urllib3 retry_after_max).",
+    )
+    max_backoff_seconds: float = Field(
+        default=120.0,
+        gt=0,
+        description="Maximum sleep seconds for exponential backoff between transport retries.",
+    )
+    backoff_jitter_seconds: float = Field(
+        default=0.0,
+        ge=0,
+        description="Maximum extra random seconds added to exponential backoff (urllib3 backoff_jitter).",
+    )
 
 
 class LoadingFormat(str, Enum):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -58,6 +58,22 @@ class APISettings(BaseSettings):
         default=1.0, description="Initial delay between retries in seconds"
     )
     RETRY_BACKOFF: float = Field(default=2.0, description="Multiplicative factor for retry delay")
+    HONOR_RETRY_AFTER_HEADER: bool = Field(
+        default=True,
+        description="Honor Retry-After on urllib3 transport retries (429/503/413).",
+    )
+    MAX_RETRY_AFTER_SECONDS: int = Field(
+        default=21600,
+        description="Upper bound for parsed Retry-After header (seconds).",
+    )
+    MAX_BACKOFF_SECONDS: float = Field(
+        default=120.0,
+        description="Maximum exponential backoff sleep between transport retries (seconds).",
+    )
+    BACKOFF_JITTER_SECONDS: float = Field(
+        default=0.0,
+        description="Maximum random extra seconds on exponential backoff (urllib3 backoff_jitter).",
+    )
 
     def update_from_config(self, config: PipelineConfig) -> None:
         """
@@ -67,9 +83,14 @@ class APISettings(BaseSettings):
             config: Pipeline configuration containing retry settings
         """
         if config.defaults and config.defaults.retry:
-            self.MAX_RETRIES = config.defaults.retry.max_attempts
-            self.INITIAL_DELAY = config.defaults.retry.initial_delay
-            self.RETRY_BACKOFF = config.defaults.retry.backoff_factor
+            r = config.defaults.retry
+            self.MAX_RETRIES = r.max_attempts
+            self.INITIAL_DELAY = r.initial_delay
+            self.RETRY_BACKOFF = r.backoff_factor
+            self.HONOR_RETRY_AFTER_HEADER = r.honor_retry_after_header
+            self.MAX_RETRY_AFTER_SECONDS = r.max_retry_after_seconds
+            self.MAX_BACKOFF_SECONDS = r.max_backoff_seconds
+            self.BACKOFF_JITTER_SECONDS = r.backoff_jitter_seconds
 
 
 class DatabricksSettings(BaseSettings):

--- a/src/service/base_service.py
+++ b/src/service/base_service.py
@@ -11,6 +11,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from src.config.settings import Settings
+from src.service.rate_limit_http import rate_limit_context_from_response
 from src.utils.exceptions import ServiceError
 from src.utils.logger import get_logger
 from src.utils.url_join import join_http_base_and_path
@@ -61,6 +62,10 @@ class BaseSourceService(ABC):
         retry_strategy = Retry(
             total=self.settings.api.MAX_RETRIES,
             backoff_factor=self.settings.api.RETRY_BACKOFF,
+            backoff_max=self.settings.api.MAX_BACKOFF_SECONDS,
+            backoff_jitter=self.settings.api.BACKOFF_JITTER_SECONDS,
+            retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
+            respect_retry_after_header=self.settings.api.HONOR_RETRY_AFTER_HEADER,
             # 401 handled separately to allow auth reset
             status_forcelist=[429, 500, 502, 503, 504, 507, 508, 509],
             allowed_methods=["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
@@ -69,8 +74,6 @@ class BaseSourceService(ABC):
             connect=self.settings.api.MAX_RETRIES,
             read=self.settings.api.MAX_RETRIES,
             redirect=3,
-            # Don't respect Retry-After headers - use our backoff strategy
-            respect_retry_after_header=False,
         )
 
         # Configure adapter with retry strategy
@@ -176,8 +179,19 @@ class BaseSourceService(ABC):
                 except ValueError:
                     error_info["response_text"] = response.text[:200]
 
-                # Log the error
-                self.logger.error("API request failed", extra_fields=error_info)
+                if response.status_code in (429, 503):
+                    error_info.update(
+                        rate_limit_context_from_response(
+                            response,
+                            retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
+                        )
+                    )
+                    self.logger.warning(
+                        "API request failed (rate limited or unavailable)",
+                        extra_fields=error_info,
+                    )
+                else:
+                    self.logger.error("API request failed", extra_fields=error_info)
 
                 # Check for auth failure that needs token reset
                 auth_needs_reset = response.status_code == 401 and any(

--- a/src/service/base_service.py
+++ b/src/service/base_service.py
@@ -11,7 +11,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from src.config.settings import Settings
-from src.service.rate_limit_http import rate_limit_context_from_response
+from src.service.rate_limit_http import rate_limit_observability_for_error_response
 from src.utils.exceptions import ServiceError
 from src.utils.logger import get_logger
 from src.utils.url_join import join_http_base_and_path
@@ -179,13 +179,12 @@ class BaseSourceService(ABC):
                 except ValueError:
                     error_info["response_text"] = response.text[:200]
 
-                if response.status_code in (429, 503):
-                    error_info.update(
-                        rate_limit_context_from_response(
-                            response,
-                            retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
-                        )
-                    )
+                rl_ctx, rate_limit_style_log = rate_limit_observability_for_error_response(
+                    response,
+                    retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
+                )
+                error_info.update(rl_ctx)
+                if rate_limit_style_log:
                     self.logger.warning(
                         "API request failed (rate limited or unavailable)",
                         extra_fields=error_info,

--- a/src/service/rate_limit_http.py
+++ b/src/service/rate_limit_http.py
@@ -1,0 +1,70 @@
+"""
+Retry-After and rate-limit header helpers for HTTP client observability.
+
+Uses urllib3's ``Retry.parse_retry_after`` so caps match transport behavior.
+"""
+
+from typing import Any, Dict, Mapping, Optional
+
+import requests
+from urllib3.exceptions import InvalidHeader
+from urllib3.util.retry import Retry
+
+from src.audit import mask_headers
+
+
+def _retry_with_cap(retry_after_max: int) -> Retry:
+    return Retry(retry_after_max=retry_after_max)
+
+
+def parse_retry_after_seconds(
+    retry_after_header: str,
+    *,
+    retry_after_max: int,
+) -> Optional[float]:
+    """
+    Parse a Retry-After header value using urllib3 rules and the same cap as transport retries.
+
+    Returns None if the header is missing, invalid, or unparsable.
+    """
+    try:
+        return float(_retry_with_cap(retry_after_max).parse_retry_after(retry_after_header.strip()))
+    except (InvalidHeader, ValueError):
+        return None
+
+
+def _is_rate_limit_header_name(name: str) -> bool:
+    lower = name.lower()
+    if lower == "retry-after":
+        return True
+    return lower.startswith("x-ratelimit-") or lower.startswith("ratelimit-")
+
+
+def extract_rate_limit_headers(
+    headers: Mapping[str, str],
+    *,
+    mask: bool = True,
+) -> Dict[str, str]:
+    """Return whitelisted rate-limit-related headers for logs and ServiceError.details."""
+    raw = {k: v for k, v in headers.items() if _is_rate_limit_header_name(k)}
+    if not raw:
+        return {}
+    return dict(mask_headers(raw)) if mask else dict(raw)
+
+
+def rate_limit_context_from_response(
+    response: requests.Response,
+    *,
+    retry_after_max: int,
+) -> Dict[str, Any]:
+    """Build structured fields for ServiceError.details and structured logging."""
+    out: Dict[str, Any] = {}
+    hdrs = extract_rate_limit_headers(dict(response.headers), mask=True)
+    if hdrs:
+        out["rate_limit_headers"] = hdrs
+    ra = response.headers.get("Retry-After")
+    if ra:
+        parsed = parse_retry_after_seconds(ra, retry_after_max=retry_after_max)
+        if parsed is not None:
+            out["retry_after_seconds"] = parsed
+    return out

--- a/src/service/rate_limit_http.py
+++ b/src/service/rate_limit_http.py
@@ -4,7 +4,7 @@ Retry-After and rate-limit header helpers for HTTP client observability.
 Uses urllib3's ``Retry.parse_retry_after`` so caps match transport behavior.
 """
 
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 import requests
 from urllib3.exceptions import InvalidHeader
@@ -68,3 +68,26 @@ def rate_limit_context_from_response(
         if parsed is not None:
             out["retry_after_seconds"] = parsed
     return out
+
+
+def rate_limit_observability_for_error_response(
+    response: requests.Response,
+    *,
+    retry_after_max: int,
+) -> Tuple[Dict[str, Any], bool]:
+    """
+    Structured fields and log severity hint for a non-OK HTTP response.
+
+    Returns ``(extra_fields, use_rate_limit_style_log)``. When
+    ``use_rate_limit_style_log`` is true, callers should use the same warning
+    path as for 429/503 (rate limited or unavailable). For 413, that applies
+    only when ``Retry-After`` or whitelisted rate-limit headers produced
+    non-empty context, matching urllib3 transport retries on 413 with headers.
+    """
+    code = response.status_code
+    if code not in (429, 503, 413):
+        return {}, False
+    ctx = rate_limit_context_from_response(response, retry_after_max=retry_after_max)
+    if code in (429, 503):
+        return ctx, True
+    return ctx, bool(ctx)

--- a/src/service/rest_service.py
+++ b/src/service/rest_service.py
@@ -22,7 +22,7 @@ from src.auth.jwt_providers import get_provider
 from src.config.config_models import ResourceConfig, SourceConfig
 from src.config.settings import Settings
 from src.service.base_service import BaseSourceService, ServiceError
-from src.service.rate_limit_http import rate_limit_context_from_response
+from src.service.rate_limit_http import rate_limit_observability_for_error_response
 from src.utils.data_utils import dict_response_key_to_records
 from src.utils.dynamic_values import get_resolver, resolve_headers_dict, resolve_request_body
 from src.utils.logger import REDACTED_PLACEHOLDER, get_logger, redact_text
@@ -686,12 +686,10 @@ class RestService(BaseSourceService):
                     except ValueError:
                         error_detail = f": {response.text[:200]}"
 
-                    rl_ctx: Dict[str, Any] = {}
-                    if response.status_code in (429, 503):
-                        rl_ctx = rate_limit_context_from_response(
-                            response,
-                            retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
-                        )
+                    rl_ctx, rate_limit_style_log = rate_limit_observability_for_error_response(
+                        response,
+                        retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
+                    )
 
                     log_payload = {
                         "status_code": response.status_code,
@@ -703,7 +701,7 @@ class RestService(BaseSourceService):
                         **rl_ctx,
                     }
 
-                    if response.status_code in (429, 503):
+                    if rate_limit_style_log:
                         self.logger.warning(
                             "Request failed (rate limited or unavailable)",
                             extra_fields=log_payload,

--- a/src/service/rest_service.py
+++ b/src/service/rest_service.py
@@ -22,6 +22,7 @@ from src.auth.jwt_providers import get_provider
 from src.config.config_models import ResourceConfig, SourceConfig
 from src.config.settings import Settings
 from src.service.base_service import BaseSourceService, ServiceError
+from src.service.rate_limit_http import rate_limit_context_from_response
 from src.utils.data_utils import dict_response_key_to_records
 from src.utils.dynamic_values import get_resolver, resolve_headers_dict, resolve_request_body
 from src.utils.logger import REDACTED_PLACEHOLDER, get_logger, redact_text
@@ -685,17 +686,30 @@ class RestService(BaseSourceService):
                     except ValueError:
                         error_detail = f": {response.text[:200]}"
 
-                    self.logger.error(
-                        "Request failed",
-                        extra_fields={
-                            "status_code": response.status_code,
-                            "error_detail": error_detail,
-                            "method": resource.method,
-                            "url": url,
-                            "attempt": retry_count + 1,
-                            "max_attempts": max_retries + 1,
-                        },
-                    )
+                    rl_ctx: Dict[str, Any] = {}
+                    if response.status_code in (429, 503):
+                        rl_ctx = rate_limit_context_from_response(
+                            response,
+                            retry_after_max=self.settings.api.MAX_RETRY_AFTER_SECONDS,
+                        )
+
+                    log_payload = {
+                        "status_code": response.status_code,
+                        "error_detail": error_detail,
+                        "method": resource.method,
+                        "url": url,
+                        "attempt": retry_count + 1,
+                        "max_attempts": max_retries + 1,
+                        **rl_ctx,
+                    }
+
+                    if response.status_code in (429, 503):
+                        self.logger.warning(
+                            "Request failed (rate limited or unavailable)",
+                            extra_fields=log_payload,
+                        )
+                    else:
+                        self.logger.error("Request failed", extra_fields=log_payload)
 
                     # Check for auth failure
                     is_auth_failure = response.status_code == 401 and any(
@@ -729,6 +743,24 @@ class RestService(BaseSourceService):
                                     "max_attempts": max_retries + 1,
                                 },
                             )
+
+                    if response.status_code in (429, 503):
+                        raise ServiceError(
+                            message=(f"API request failed with status {response.status_code}"),
+                            operation=f"{resource.method} {url}",
+                            service_name=self.__class__.__name__,
+                            is_retryable=True,
+                            details={
+                                "status_code": response.status_code,
+                                "error_detail": error_detail,
+                                "method": resource.method,
+                                "url": url,
+                                "resource_name": resource_name,
+                                "attempt": retry_count + 1,
+                                "max_attempts": max_retries + 1,
+                                **rl_ctx,
+                            },
+                        )
 
                     # For non-auth failures or if we're out of retries, raise
                     response.raise_for_status()

--- a/tests/test_config/test_retry_config.py
+++ b/tests/test_config/test_retry_config.py
@@ -1,0 +1,45 @@
+"""Tests for RetryConfig HTTP transport fields."""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.config_models import RetryConfig
+from src.config.settings import APISettings
+
+
+def test_retry_config_defaults() -> None:
+    r = RetryConfig()
+    assert r.max_attempts == 3
+    assert r.honor_retry_after_header is True
+    assert r.max_retry_after_seconds == 21600
+    assert r.max_backoff_seconds == 120.0
+    assert r.backoff_jitter_seconds == 0.0
+
+
+def test_retry_config_validation_max_retry_after_ge_one() -> None:
+    with pytest.raises(ValidationError):
+        RetryConfig(max_retry_after_seconds=0)
+
+
+def test_api_settings_update_from_config_maps_http_retry_fields() -> None:
+    retry = RetryConfig(
+        max_attempts=5,
+        initial_delay=2.0,
+        backoff_factor=3.0,
+        honor_retry_after_header=False,
+        max_retry_after_seconds=120,
+        max_backoff_seconds=45.0,
+        backoff_jitter_seconds=2.0,
+    )
+    config = SimpleNamespace(defaults=SimpleNamespace(retry=retry))
+    api = APISettings()
+    api.update_from_config(config)
+    assert api.MAX_RETRIES == 5
+    assert api.INITIAL_DELAY == 2.0
+    assert api.RETRY_BACKOFF == 3.0
+    assert api.HONOR_RETRY_AFTER_HEADER is False
+    assert api.MAX_RETRY_AFTER_SECONDS == 120
+    assert api.MAX_BACKOFF_SECONDS == 45.0
+    assert api.BACKOFF_JITTER_SECONDS == 2.0

--- a/tests/test_service/test_rate_limit_http.py
+++ b/tests/test_service/test_rate_limit_http.py
@@ -1,0 +1,47 @@
+"""Tests for Retry-After parsing and rate-limit header extraction."""
+
+from unittest.mock import MagicMock
+
+from src.service.rate_limit_http import (
+    extract_rate_limit_headers,
+    parse_retry_after_seconds,
+    rate_limit_context_from_response,
+)
+
+
+def test_parse_retry_after_seconds_integer() -> None:
+    assert parse_retry_after_seconds("2", retry_after_max=100) == 2.0
+
+
+def test_parse_retry_after_seconds_respects_cap() -> None:
+    assert parse_retry_after_seconds("999999", retry_after_max=10) == 10.0
+
+
+def test_parse_retry_after_seconds_invalid_returns_none() -> None:
+    assert parse_retry_after_seconds("not-a-date", retry_after_max=100) is None
+
+
+def test_extract_rate_limit_headers_whitelist_only() -> None:
+    headers = {
+        "Retry-After": "5",
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": "1234567890",
+        "Authorization": "Bearer secret",
+        "Content-Type": "application/json",
+    }
+    out = extract_rate_limit_headers(headers, mask=False)
+    assert "Authorization" not in out
+    assert out["Retry-After"] == "5"
+    assert out["X-RateLimit-Remaining"] == "0"
+
+
+def test_rate_limit_context_from_response() -> None:
+    mock_response = MagicMock()
+    mock_response.headers = {
+        "Retry-After": "2",
+        "X-RateLimit-Remaining": "0",
+    }
+    ctx = rate_limit_context_from_response(mock_response, retry_after_max=60)
+    assert ctx["retry_after_seconds"] == 2.0
+    assert "rate_limit_headers" in ctx
+    assert "0" in ctx["rate_limit_headers"]["X-RateLimit-Remaining"]

--- a/tests/test_service/test_rate_limit_http.py
+++ b/tests/test_service/test_rate_limit_http.py
@@ -6,6 +6,7 @@ from src.service.rate_limit_http import (
     extract_rate_limit_headers,
     parse_retry_after_seconds,
     rate_limit_context_from_response,
+    rate_limit_observability_for_error_response,
 )
 
 
@@ -45,3 +46,69 @@ def test_rate_limit_context_from_response() -> None:
     assert ctx["retry_after_seconds"] == 2.0
     assert "rate_limit_headers" in ctx
     assert "0" in ctx["rate_limit_headers"]["X-RateLimit-Remaining"]
+
+
+def test_observability_429_warns_even_without_headers() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.headers = {}
+    ctx, use_rl_log = rate_limit_observability_for_error_response(
+        mock_response, retry_after_max=60
+    )
+    assert ctx == {}
+    assert use_rl_log is True
+
+
+def test_observability_503_warns_even_without_headers() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.headers = {}
+    ctx, use_rl_log = rate_limit_observability_for_error_response(
+        mock_response, retry_after_max=60
+    )
+    assert ctx == {}
+    assert use_rl_log is True
+
+
+def test_observability_413_with_retry_after() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 413
+    mock_response.headers = {"Retry-After": "3"}
+    ctx, use_rl_log = rate_limit_observability_for_error_response(
+        mock_response, retry_after_max=60
+    )
+    assert ctx["retry_after_seconds"] == 3.0
+    assert use_rl_log is True
+
+
+def test_observability_413_without_headers() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 413
+    mock_response.headers = {}
+    ctx, use_rl_log = rate_limit_observability_for_error_response(
+        mock_response, retry_after_max=60
+    )
+    assert ctx == {}
+    assert use_rl_log is False
+
+
+def test_observability_413_x_ratelimit_only() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 413
+    mock_response.headers = {"X-RateLimit-Remaining": "0"}
+    ctx, use_rl_log = rate_limit_observability_for_error_response(
+        mock_response, retry_after_max=60
+    )
+    assert "rate_limit_headers" in ctx
+    assert use_rl_log is True
+
+
+def test_observability_other_status_no_context() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.headers = {"Retry-After": "9"}
+    ctx, use_rl_log = rate_limit_observability_for_error_response(
+        mock_response, retry_after_max=60
+    )
+    assert ctx == {}
+    assert use_rl_log is False


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

The HTTP client now respects Retry-After on retries, with a configurable cap and optional jitter on exponential backoff. When a request still fails with 429 or 503, logs and ServiceError details include parsed wait time, masked rate-limit related headers, and attempt context where applicable.

Why?

Providers expect clients to follow Retry-After. Ignoring it risked hitting APIs too hard and made throttling harder to debug. This matches the First-class HTTP 429 rate-limit handling work.



## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

<!-- Issue or ticket link, if any -->
https://github.com/victorlou/spine/issues/8
https://github.com/victorlou/spine/issues/8