### PR TITLE
feat(ci): Add dev image publishing, build and smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [dev, main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   contents: read
 
@@ -88,7 +88,7 @@ jobs:
       - name: Load configuration files
         run: |
           cp config/defaults.example.yml config/defaults.yml
-          mkdir -p config/examples
+          mkdir -p config/sources
           cp config/examples/jsonplaceholder.yml config/sources/jsonplaceholder.yml
 
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [dev, main]
-
+    types: [opened, synchronize, reopened]
 permissions:
   contents: read
 
@@ -56,11 +56,129 @@ jobs:
           --cov-report=xml
           --cov-fail-under=85
 
+  change-diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      docker-impacting: ${{ steps.filter.outputs.docker-impacting }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Tradeoff: path-gating saves CI minutes by avoiding Docker work for docs/config-only PRs,
+      # but it is intentionally simpler than proving every indirect Docker build input.
+      - name: Detect Docker-impacting changes
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            docker-impacting:
+              - 'docker/**'
+              - 'requirements*.txt'
+              - 'src/**'
+
+  build:
+    needs: [lint, test, change-diff]
+    if: github.event_name == 'pull_request' && needs.change-diff.outputs.docker-impacting == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load configuration files
+        run: |
+          cp config/defaults.example.yml config/defaults.yml
+          mkdir -p config/examples
+          cp config/examples/jsonplaceholder.yml config/sources/jsonplaceholder.yml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: spine:latest
+
+      - name: Export image as artifact
+        run: docker save spine:latest | gzip > spine.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spine-image
+          path: spine.tar.gz
+          retention-days: 1
+
+  docker-smoke:
+    needs: [build, change-diff]
+    if: github.event_name == 'pull_request' && needs.change-diff.outputs.docker-impacting == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spine-image
+
+      - name: Load image
+        run: docker load --input spine.tar.gz
+
+      - name: Run smoke test
+        timeout-minutes: 2
+        run: docker run --rm spine:latest --show-plan
+
+
+  dev-image-smoke:
+    needs: [lint, test]
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'main' &&
+      github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Image name (lowercase for GHCR)
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare example config
+        run: |
+          mkdir -p .ci/smoke-config/sources
+          cp config/defaults.example.yml .ci/smoke-config/defaults.yml
+          cp config/examples/jsonplaceholder.yml .ci/smoke-config/sources/jsonplaceholder.yml
+
+      - name: Pull dev image
+        run: docker pull ${{ steps.image.outputs.name }}:dev
+
+      - name: Run dev image smoke test
+        timeout-minutes: 2
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/.ci/smoke-config:/config:ro" \
+            "${{ steps.image.outputs.name }}:dev" \
+            --show-plan
+
   build-and-push:
     needs: [lint, test]
     if: >-
       github.event_name == 'push' &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -90,6 +208,8 @@ jobs:
           tags: |
             type=sha
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=sha,prefix=dev-,format=short,enable=${{ github.ref == 'refs/heads/dev' }}
             type=ref,event=tag
 
       - name: Build and push

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -28,6 +28,6 @@ jobs:
           owner: ${{ steps.package.outputs.owner }}
           repository: ${{ steps.package.outputs.repository }}
           package: ${{ steps.package.outputs.repository }}
-          exclude-tags: ^(?:latest|v.*)$
+          exclude-tags: ^(?:latest|dev|v.*)$
           keep-n-tagged: 10
           keep-n-untagged: 0

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -21,6 +21,40 @@ jobs:
           echo "owner=${owner}" >> "$GITHUB_OUTPUT"
           echo "repository=${repository}" >> "$GITHUB_OUTPUT"
 
+      # Keep the rolling `dev` tag plus the three newest `dev-<short_sha>` traces; older
+      # trace-only versions are removed here. The next step applies generic retention
+      # for other tags (SHA, and so on).
+      - name: Prune old dev-<sha> package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          OWNER="${{ steps.package.outputs.owner }}"
+          PACKAGE="${{ steps.package.outputs.repository }}"
+          KEEP_TRACE=3
+          owner_type="$(gh api "repos/${{ github.repository }}" --jq -r .owner.type)"
+          if [ "${owner_type}" = "Organization" ]; then
+            PKG_ROOT="orgs/${OWNER}/packages/container/${PACKAGE}"
+          else
+            PKG_ROOT="users/${OWNER}/packages/container/${PACKAGE}"
+          fi
+          mapfile -t DELETE_IDS < <(
+            gh api --paginate "${PKG_ROOT}/versions" --jq -r --argjson keep "$KEEP_TRACE" '
+              [
+                .[] | select(
+                  (.metadata.container.tags // []) as $t |
+                  ($t | index("dev") == null) and
+                  ($t | index("latest") == null) and
+                  ($t | map(test("^dev-.+$")) | any)
+                )
+              ] | sort_by(.updated_at) | reverse | .[$keep:] | .[].id
+            '
+          )
+          for id in "${DELETE_IDS[@]}"; do
+            [ -z "${id}" ] && continue
+            gh api --method DELETE "${PKG_ROOT}/versions/${id}" --silent
+          done
+
       - name: Cleanup obsolete GHCR tags and manifests
         uses: jenskeiner/ghcr-container-repository-cleanup-action@v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Spine is a configuration-first ingestion framework. Treat it like production pip
 
 - Keep the `README.md` practical and honest. Personality is fine, but claims should match the implementation.
 - Use `docs/getting-started.md`, `docs/deployment.md`, and `docs/configuration/` as the source of truth for setup and behavior details.
+- GHCR image tags (`latest`, rolling `dev`, short-lived `dev-<short_sha>` traces, `v*`), PR Docker path gates, promotion smoke, and registry cleanup live in `docs/deployment.md`, `docker/README.md`, and `docs/development.md`; update them when CI or publishing behavior changes.
 - Write for someone discovering the project for the first time. Prefer direct, timeless descriptions of behavior and configuration. Avoid framing docs around past releases or repo history (for example “unchanged from earlier versions”, “previously”, “now you can”) unless you are explicitly documenting a breaking migration or upgrade path.
 
 ## GitHub issues

--- a/docker/README.md
+++ b/docker/README.md
@@ -74,12 +74,21 @@ docker run --rm \
 
 ## CI-built images
 
-On pushes to **`main`** or **`v*` version tags**, GitHub Actions publishes a multi-arch image (manifest list for `linux/amd64` and `linux/arm64`) to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)). Pull with your organization or user name and the repository name in lowercase, for example `docker pull ghcr.io/victorlou/spine:latest` or `docker pull ghcr.io/victorlou/spine:v1.0.0`.
+On pushes to **`main`**, **`dev`**, or **`v*` version tags**, GitHub Actions publishes a multi-arch image (manifest list for `linux/amd64` and `linux/arm64`) to `ghcr.io` (see [docs/deployment.md](../docs/deployment.md)).
+
+Typical pulls (use your org/user and repo name in lowercase):
+
+- **`docker pull ghcr.io/victorlou/spine:latest`** — tracks **`main`** (release-style default).
+- **`docker pull ghcr.io/victorlou/spine:dev`** — tracks the **latest push to `dev`**; the tag is **mutable**. **`dev-<short_sha>`** pins a recent commit; scheduled cleanup keeps the **three** newest trace tags (plus rolling **`dev`**); see [docs/deployment.md](../docs/deployment.md).
+- **`docker pull ghcr.io/victorlou/spine:v1.0.0`** — immutable release tag.
+
+Pull requests that change **`docker/**`**, **`requirements*.txt`**, or **`src/**`** get a CI Docker build (no push) and a minimal container smoke (`--show-plan`). Pull requests from **`dev`** into **`main`** also run a smoke against the **published** `:dev` image with mounted example config.
 
 Verify published manifest platforms with:
 
 ```bash
 docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
+docker buildx imagetools inspect ghcr.io/victorlou/spine:dev
 ```
 
 Runtime configuration in production should come from your orchestrator (secrets, task env), not from baking `.env` into the image.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,30 +20,22 @@ For full details (CLI args, Apple Silicon), see [docker/README.md](../docker/REA
 
 ## CI and container images (GitHub Actions)
 
-Linting and tests run on pushes and pull requests to **`dev`** and **`main`**, and on **version tag** pushes (`v*`), via [.github/workflows/ci.yml](../.github/workflows/ci.yml).
+Linting and tests run on pushes and pull requests to **`dev`** and **`main`**, and on **`v*`** tag pushes, via [.github/workflows/ci.yml](../.github/workflows/ci.yml).
 
-The workflow **builds and pushes** a multi-arch container image (manifest list for `linux/amd64` and `linux/arm64`) to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`) on pushes to **`main`** and on **`v*` tags** (for example `ghcr.io/victorlou/spine:latest` plus a SHA tag on `main`, and `ghcr.io/victorlou/spine:v1.2.3` when you push tag `v1.2.3`). Pushes to `dev` only run lint and tests.
+**GHCR publishes** a multi-arch image (`linux/amd64`, `linux/arm64`) on pushes to **`main`** (`latest` + SHA metadata), **`dev`** (mutable **`dev`** plus **`dev-<short_sha>`** traces), and **`v*`** tags. Multi-arch manifests explain multiple digests per logical tag.
 
-The package may show multiple digests for a single publish. That is expected for multi-arch images: one top-level manifest list plus child manifests for each architecture.
+**PRs:** optional Docker **build** (no push) and **`docker run … --show-plan`** smoke run only when the diff touches **`docker/**`**, **`requirements*.txt`**, or **`src/**`** (see path filter comment in `ci.yml`). **`dev-image-smoke`** runs on PRs **`dev` → `main`**: pulls the published **`ghcr.io/<owner>/<repo>:dev`** (lowercase path), mounts example config at **`/config`**, runs **`--show-plan`** (tests the registry’s **`:dev`**, not necessarily the PR’s merge preview until `dev` is pushed). Requires **`packages: read`**. Fork PRs use the fork’s package coordinates; promotion is normally same-repo.
 
-Requirements for the image job:
+**Branch protection:** add **`dev-image-smoke`** as a required check for **`main`** if merges should be blocked when it fails (Settings → rules / branch protection).
 
-- **Packages** permission for `GITHUB_TOKEN` (the workflow grants `packages: write` on the publish job only).
-
-Images are public or private according to your GitHub package visibility settings for the container package.
-
-After publish, you can verify manifest platforms with:
+**Cleanup** ([`.github/workflows/ghcr-cleanup.yml`](../.github/workflows/ghcr-cleanup.yml)): weekly job keeps **`latest`**, **`dev`**, **`v*`**, then the **three newest** package versions that carry **`dev-<short_sha>`** but **not** the rolling **`dev`** tag; a follow-up step keeps **10** other tagged versions and drops untagged (`keep-n-tagged` / `keep-n-untagged` in the workflow).
 
 ```bash
 docker buildx imagetools inspect ghcr.io/victorlou/spine:latest
+docker buildx imagetools inspect ghcr.io/victorlou/spine:dev
 ```
 
-A separate weekly cleanup workflow keeps the registry tidy while preserving multi-arch integrity:
-
-- keep `latest`
-- keep all `v*` tags
-- keep the 10 most recent SHA tags
-- delete untagged versions
+Publish job needs **`packages: write`** on `GITHUB_TOKEN`. Image visibility follows the package settings on GitHub.
 
 ## Runtime configuration
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,9 +30,22 @@ Without activating the venv, the same tools work as `uv run black …`, `uv run 
 
 ### CI
 
-GitHub Actions runs the same lint commands as above, installs dependencies with **`uv sync --frozen --all-groups`** (from [`uv.lock`](../uv.lock)), and runs **`uv run pytest`** with **`--cov-fail-under=85`** on **pull requests and pushes to `dev` and `main`**, and on **pushes of version tags** (`v*`). A container image is **built and pushed to GHCR on pushes to `main`** (including `latest` and a SHA tag) **and on `v*` tag pushes** (image tagged with the release version). No private package index or repository secrets are required for the default pipeline.
+GitHub Actions runs the same lint commands as above, installs dependencies with **`uv sync --frozen --all-groups`** (from [`uv.lock`](../uv.lock)), and runs **`uv run pytest`** with **`--cov-fail-under=85`** on **pull requests and pushes to `dev` and `main`**, and on **pushes of version tags** (`v*`).
 
-See [.github/workflows/ci.yml](../.github/workflows/ci.yml).
+Container publishing:
+
+- **`main`**: push **`latest`** plus SHA tags to GHCR.
+- **`dev`**: push **`dev`** (rolling, mutable) plus **`dev-<short_sha>`** to GHCR; cleanup keeps the **three** newest trace tags besides **`dev`** (see [deployment.md](deployment.md#ci-and-container-images-github-actions)).
+- **`v*` tags**: push version-tagged images.
+
+Pull request Docker checks (see [.github/workflows/ci.yml](../.github/workflows/ci.yml)):
+
+- **Path filter:** a Docker **build** (no push) and **`docker-smoke`** run only when the PR changes **`docker/**`**, **`requirements*.txt`**, or **`src/**`**. Other edits (docs-only, config templates only, and so on) skip those jobs to save CI time; `pyproject.toml` / **`uv.lock`**-only changes do **not** trigger the Docker job unless they also touch those paths—run a local **`docker build -f docker/Dockerfile .`** before merging if you rely on lockfile-only Dockerfile behavior.
+- **Promotion smoke:** PRs with **`base` = `main`** and **`head` = `dev`** run **`dev-image-smoke`**, which pulls the published **`ghcr.io/.../spine:dev`** image and runs **`--show-plan`** with example config. Repository maintainers should treat **`dev-image-smoke`** as a **required check** for **`main`** if merges should be blocked when that step fails.
+
+Workflow triggers include **`ready_for_review`** so marking a draft PR as ready re-runs CI without requiring an empty commit.
+
+No private package index or repository secrets are required for the default pipeline (beyond `GITHUB_TOKEN` permissions declared in the workflow).
 
 ### Pre-commit (git hooks)
 


### PR DESCRIPTION
Resolves #16 and #18

## Summary

<!-- What does this PR change and why? -->

- Added PR Docker validation for Docker-impacting changes only, using path filtering for `docker/**`, `requirements*.txt`, and `src/**` to reduce unnecessary CI minutes.
- Added a Docker build job for PRs that builds the image without pushing, exports it as an artifact, and reuses it in a smoke test instead of rebuilding.
- Added a short Docker smoke test with timeouts to catch broken image startup / entrypoint behavior quickly.
- Extended image publishing so pushes to `dev` publish GHCR `dev` and `dev-<short_sha>` tags, while `main` continues publishing `latest` and version tags continue using `v*`.
- Added a dev-to-main promotion smoke gate that pulls the published `ghcr.io/.../spine:dev` image and runs it against example config.
- Updated GHCR cleanup rules to preserve dev image tags from scheduled cleanup.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.