### PR TITLE
fix: enable `jsonplaceholder.yml` in ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: 'Setup yq'
+        uses: dcarbone/install-yq-action@v1
+        with:
+          version: "v4.44.3"
+
       - name: Load configuration files
         run: |
           cp config/defaults.example.yml config/defaults.yml
           mkdir -p config/sources
           cp config/examples/jsonplaceholder.yml config/sources/jsonplaceholder.yml
+          yq e -i '.enabled = true' config/sources/jsonplaceholder.yml
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -157,11 +163,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Setup yq'
+        uses: dcarbone/install-yq-action@v1
+        with:
+          version: "v4.44.3"
+
       - name: Prepare example config
         run: |
           mkdir -p .ci/smoke-config/sources
           cp config/defaults.example.yml .ci/smoke-config/defaults.yml
           cp config/examples/jsonplaceholder.yml .ci/smoke-config/sources/jsonplaceholder.yml
+          yq e -i '.enabled = true' .ci/smoke-config/sources/jsonplaceholder.yml
 
       - name: Pull dev image
         run: docker pull ${{ steps.image.outputs.name }}:dev


### PR DESCRIPTION
## Context:

<img width="1241" height="514" alt="image" src="https://github.com/user-attachments/assets/c3ac5eb6-5d07-4041-bb10-2868efeb395f" />
<br />

Run Smoke step on `docker-smoke` stage returned 0 stages instead of 3.

Core bug: 
- `jsonplaceholder.yml` was disabled by default

## Summary

<!-- What does this PR change and why? -->

- Enabled example source `jsonplaceholder.yml` in CI smoke jobs (`build` and `dev-image-smoke`)
- Install yq in Docker jobs to toggle the copied `jsonplaceholder` config on while keeping the template disabled.

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.
