### PR TITLE
fix: rest parser response_key unwrap and bearer token refresh content…

### DIFF
--- a/docs/configuration/auth.md
+++ b/docs/configuration/auth.md
@@ -70,9 +70,17 @@ auth:
   client_id: "${CLIENT_ID}"
   client_secret: "${CLIENT_SECRET}"
   refresh_token: "${REFRESH_TOKEN}"
+  token_request_content_type: "json"  # "json" (default) or "form"
   header_name: "Authorization"
   header_format: "Bearer {token}"
 ```
+
+`token_request_content_type` controls how the token refresh request body is encoded:
+
+| Value | Content-Type | Use when |
+|-------|-------------|----------|
+| `json` (default) | `application/json` | Most APIs |
+| `form` | `application/x-www-form-urlencoded` | APIs that require form-encoded bodies (e.g. Snapchat Ads) |
 
 ## API Key
 

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -810,8 +810,18 @@ class AuthConfig(BaseModel):
     )
     issuer: Optional[str] = None  # Required for oauth_jwt
     private_key: Optional[str] = None  # Base64 encoded private key for oauth_jwt
-    bearer_token: Optional[str] = None  # Required for bearer_token auth
+    bearer_token: Optional[str] = (
+        None  # Required for bearer_token auth (unless refresh credentials provided)
+    )
     refresh_token: Optional[str] = None  # Optional for bearer_token (enables auto-refresh)
+    token_request_content_type: Literal["json", "form"] = Field(
+        default="json",
+        description=(
+            "Content type for token refresh requests: 'json' sends application/json "
+            "(request body as JSON), 'form' sends application/x-www-form-urlencoded "
+            "(request body as form data). Most OAuth2 providers expect 'form'."
+        ),
+    )
     header_name: str = "Authorization"  # Name of the auth header
     header_format: str = "Bearer {token}"  # Format string for the auth header value
     jwt_config: Optional[JWTConfig] = None  # JWT-specific settings, required for oauth_jwt
@@ -852,8 +862,14 @@ class AuthConfig(BaseModel):
                 raise ValueError("client_id is required for api_key authentication")
 
         elif self.type == "bearer_token":
-            if not self.bearer_token:
-                raise ValueError("bearer_token is required for bearer_token authentication")
+            has_refresh_credentials = all(
+                [self.token_url, self.client_id, self.client_secret, self.refresh_token]
+            )
+            if not self.bearer_token and not has_refresh_credentials:
+                raise ValueError(
+                    "bearer_token authentication requires either a static bearer_token "
+                    "or all refresh credentials (token_url, client_id, client_secret, refresh_token)"
+                )
 
         return self
 

--- a/src/parser/spark_parser.py
+++ b/src/parser/spark_parser.py
@@ -420,8 +420,20 @@ class SparkParser:
         # Convert single dict to list
         records = data if isinstance(data, list) else [data]
 
-        # Handle nested data structures (dot paths via get_nested_value; same as REST/SDK)
-        if len(records) == 1 and isinstance(records[0], dict) and self.config.response_key:
+        # Handle nested data structures (dot paths via get_nested_value; same as REST/SDK).
+        # Unwrap when the first record is a dict that still contains the response_key at the
+        # top level. This covers two cases:
+        #   1. input was a raw dict (e.g. {"accounts": [...]}) — always unwrap.
+        #   2. input was a list whose sole element is a wrapper dict (e.g. [{"accounts": [...]}])
+        #      — unwrap only if the key is present, so we don't re-apply to already-extracted
+        #      single-item lists where RestService already unwrapped upstream (snapchat_ads case).
+        first_record_has_key = (
+            len(records) == 1
+            and isinstance(records[0], dict)
+            and self.config.response_key
+            and self.config.response_key in records[0]
+        )
+        if first_record_has_key:
             nested_list, missing = dict_response_key_to_records(
                 records[0], self.config.response_key
             )

--- a/src/service/rest_service.py
+++ b/src/service/rest_service.py
@@ -325,6 +325,9 @@ class RestService(BaseSourceService):
 
         content_type = getattr(self.config.auth, "token_request_content_type", "json")
 
+        # RFC 6749 specifies form-encoded as the OAuth2 standard for token requests;
+        # some providers also accept JSON as a convenience. Use token_request_content_type
+        # in the source auth config to select the format the provider requires.
         if content_type == "form":
             response = self.session.post(
                 url=str(self.config.auth.token_url),

--- a/src/service/rest_service.py
+++ b/src/service/rest_service.py
@@ -316,17 +316,28 @@ class RestService(BaseSourceService):
         if not self.config.auth:
             raise ServiceError("Authentication configuration is required")
 
-        response = self.session.post(
-            url=str(self.config.auth.token_url),
-            headers={"Content-Type": "application/json"},
-            json={
-                "grant_type": "refresh_token",
-                "refresh_token": self.config.auth.refresh_token,
-                "client_id": self.config.auth.client_id,
-                "client_secret": self.config.auth.client_secret,
-            },
-            timeout=self.settings.api.TIMEOUT,
-        )
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.config.auth.refresh_token,
+            "client_id": self.config.auth.client_id,
+            "client_secret": self.config.auth.client_secret,
+        }
+
+        content_type = getattr(self.config.auth, "token_request_content_type", "json")
+
+        if content_type == "form":
+            response = self.session.post(
+                url=str(self.config.auth.token_url),
+                data=payload,
+                timeout=self.settings.api.TIMEOUT,
+            )
+        else:
+            response = self.session.post(
+                url=str(self.config.auth.token_url),
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=self.settings.api.TIMEOUT,
+            )
         response.raise_for_status()
 
         # Handle OAuth2 response formats and set token with expiry buffer

--- a/tests/test_config/test_config_models.py
+++ b/tests/test_config/test_config_models.py
@@ -622,8 +622,46 @@ def test_auth_config_bearer_token_valid() -> None:
 
 
 def test_auth_config_bearer_token_missing_raises() -> None:
-    with pytest.raises(ValidationError, match="bearer_token"):
+    with pytest.raises(ValidationError, match="bearer_token authentication requires"):
         AuthConfig(type="bearer_token")
+
+
+def test_auth_config_bearer_token_refresh_only_valid() -> None:
+    """All refresh credentials present, no static bearer_token → valid."""
+    auth = AuthConfig(
+        type="bearer_token",
+        token_url="https://auth.example.com/token",
+        client_id="cid",
+        client_secret="csecret",
+        refresh_token="rtok",
+    )
+    assert auth.bearer_token is None
+    assert auth.refresh_token == "rtok"
+
+
+def test_auth_config_bearer_token_partial_refresh_raises() -> None:
+    """Some refresh credentials missing and no static bearer_token → raises."""
+    with pytest.raises(ValidationError, match="bearer_token authentication requires"):
+        AuthConfig(
+            type="bearer_token",
+            token_url="https://auth.example.com/token",
+            client_id="cid",
+            # missing client_secret and refresh_token
+        )
+
+
+def test_auth_config_token_request_content_type_defaults_to_json() -> None:
+    auth = AuthConfig(type="bearer_token", bearer_token="tok")
+    assert auth.token_request_content_type == "json"
+
+
+def test_auth_config_token_request_content_type_form() -> None:
+    auth = AuthConfig(
+        type="bearer_token",
+        bearer_token="tok",
+        token_request_content_type="form",
+    )
+    assert auth.token_request_content_type == "form"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parser/test_spark_parser.py
+++ b/tests/test_parser/test_spark_parser.py
@@ -217,6 +217,90 @@ def test_extract_records_and_schema_response_key_non_dict_returns_empty() -> Non
     assert out["records"] == []
 
 
+def test_extract_records_single_item_list_not_re_extracted() -> None:
+    """A list with one item must not have response_key applied again.
+
+    RestService already extracts the response_key before passing data to the
+    parser.  When an account has exactly one campaign the parser receives
+    [{"sub_request_status": "SUCCESS", "campaign": {...}}].  The old code
+    hit the ``len(records) == 1`` branch and tried to find "campaigns" inside
+    that wrapper dict, found nothing, and returned 0 records.
+    """
+    fields = [
+        SchemaField(name="id", source="campaign.id"),
+        SchemaField(name="name", source="campaign.name"),
+    ]
+    parser = SparkParser(
+        config=ResourceConfig(response_key="campaigns", fields=fields),
+        spark=MagicMock(),
+        source_name="snapchat_ads",
+        resource_name="campaigns",
+        execution_plan=_plan(),
+        redis_context=MagicMock(),
+    )
+    # Already-extracted list with exactly one item (the campaign wrapper dict)
+    data = [{"sub_request_status": "SUCCESS", "campaign": {"id": "abc-123", "name": "Test"}}]
+    out = parser._extract_records_and_schema(data, None)
+    assert len(out["records"]) == 1
+    assert out["records"][0]["id"] == "abc-123"
+    assert out["records"][0]["name"] == "Test"
+
+
+def test_extract_records_raw_dict_response_key_unwrapped() -> None:
+    """When the parser receives a raw response dict it must still unwrap response_key."""
+    fields = [SchemaField(name="id", source="campaign.id")]
+    parser = SparkParser(
+        config=ResourceConfig(response_key="campaigns", fields=fields),
+        spark=MagicMock(),
+        source_name="snapchat_ads",
+        resource_name="campaigns",
+        execution_plan=_plan(),
+        redis_context=MagicMock(),
+    )
+    # Raw full response dict — needs response_key unwrapping
+    data = {
+        "request_status": "SUCCESS",
+        "campaigns": [{"campaign": {"id": "abc-123"}}],
+    }
+    out = parser._extract_records_and_schema(data, None)
+    assert len(out["records"]) == 1
+    assert out["records"][0]["id"] == "abc-123"
+
+
+def test_extract_records_list_wrapped_dict_response_key_unwrapped() -> None:
+    """API returns [{"accounts": [...]}] — a list whose sole element is the wrapper dict.
+
+    RestService only extracts response_key when the top-level response is a dict.
+    When the API itself returns a list, RestService passes it through and the parser
+    must still detect and unwrap the response_key (roundel_ads pattern).
+    """
+    fields = [
+        SchemaField(name="account_id", source="account_id"),
+        SchemaField(name="account_name", source="account_name"),
+    ]
+    parser = SparkParser(
+        config=ResourceConfig(response_key="accounts", fields=fields),
+        spark=MagicMock(),
+        source_name="roundel_ads",
+        resource_name="accounts",
+        execution_plan=_plan(),
+        redis_context=MagicMock(),
+    )
+    # API returned a list; RestService passed it through without extracting
+    data = [
+        {
+            "accounts": [
+                {"account_id": "0014R000038f8hoQAA", "account_name": "Zuru"},
+                {"account_id": "553639716177408000", "account_name": "Zuru - RMS"},
+            ]
+        }
+    ]
+    out = parser._extract_records_and_schema(data, None)
+    assert len(out["records"]) == 2
+    assert out["records"][0]["account_id"] == "0014R000038f8hoQAA"
+    assert out["records"][1]["account_id"] == "553639716177408000"
+
+
 def test_parse_ensure_param_values_skips_when_output_field_missing() -> None:
     ensure_cfg = {"enabled": True, "param_name": "id", "output_field": "missing_col"}
     parser = SparkParser(

--- a/tests/test_service/test_rest_auth_extended.py
+++ b/tests/test_service/test_rest_auth_extended.py
@@ -108,3 +108,57 @@ def test_bearer_refresh_updates_token(monkeypatch: pytest.MonkeyPatch) -> None:
     post_resp.json.return_value = {"access_token": "refreshed", "expires_in": 9000}
     svc.session.post.return_value = post_resp
     assert svc._get_auth_token() == "refreshed"
+
+
+def test_bearer_refresh_form_encoded_uses_data() -> None:
+    """token_request_content_type='form' sends payload via data= (form-encoded)."""
+    svc = _bare_rest_service(
+        type="bearer_token",
+        token_url="https://id/t",
+        client_id="c",
+        client_secret="s",
+        refresh_token="r",
+        bearer_token=None,
+        header_name="H",
+        header_format="{token}",
+        token_request_content_type="form",
+    )
+    post_resp = MagicMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json.return_value = {"access_token": "form-tok", "expires_in": 3600}
+    svc.session.post.return_value = post_resp
+
+    assert svc._get_auth_token() == "form-tok"
+
+    # Verify data= was used (form-encoded), not json=
+    call_kwargs = svc.session.post.call_args
+    assert "data" in call_kwargs.kwargs
+    assert "json" not in call_kwargs.kwargs
+    assert call_kwargs.kwargs["data"]["grant_type"] == "refresh_token"
+
+
+def test_bearer_refresh_json_uses_json_kwarg() -> None:
+    """token_request_content_type='json' (default) sends payload via json= (JSON body)."""
+    svc = _bare_rest_service(
+        type="bearer_token",
+        token_url="https://id/t",
+        client_id="c",
+        client_secret="s",
+        refresh_token="r",
+        bearer_token=None,
+        header_name="H",
+        header_format="{token}",
+        token_request_content_type="json",
+    )
+    post_resp = MagicMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json.return_value = {"access_token": "json-tok", "expires_in": 3600}
+    svc.session.post.return_value = post_resp
+
+    assert svc._get_auth_token() == "json-tok"
+
+    # Verify json= was used, not data=
+    call_kwargs = svc.session.post.call_args
+    assert "json" in call_kwargs.kwargs
+    assert "data" not in call_kwargs.kwargs
+    assert call_kwargs.kwargs["headers"] == {"Content-Type": "application/json"}


### PR DESCRIPTION
## Summary

This PR fixes two issues in the REST ingestion framework to support new REST sources without impacting existing integrations.

### Changes

#### 1. Fix response_key unwrapping logic

The parser was incorrectly re-applying `response_key` extraction to already-extracted single-item lists, causing APIs that returned exactly one record to produce zero output records.

Additionally, the previous `input_was_dict` guard introduced to address this issue caused regressions for sources whose APIs return a list-wrapped response object that is passed through unextracted by `RestService`.

**Fix:** Only unwrap when the first record actually contains the configured `response_key`, allowing the parser to correctly distinguish between extracted and unextracted payloads.

#### 2. Support form-encoded bearer token refresh requests

Bearer token refresh requests were always sent as JSON. Some OAuth/token endpoints require requests to be sent as `application/x-www-form-urlencoded`.

**Fixes:**

* Added `token_request_content_type` (`json` | `form`, default: `json`) to `AuthConfig`.
* Wired the configuration through the token refresh flow in `RestService`.
* Relaxed bearer token validation to allow omission of a static token when refresh credentials are provided.

## Checklist

* [x] I have described the change clearly enough for reviewers.
* [x] I ran lint and tests locally (or noted why not).
* [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs.

## Related

<!-- Issue or ticket link, if any -->

