### PR TITLE
fix:  401 'signature has expired'. by re-resolving the headers per batch

### DIFF
--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -127,10 +127,6 @@ class DynamicHandler(BaseHandler):
         self.config = settings.pipeline_config
         self.record_limit = record_limit
         self.backfill_mode = backfill_mode
-        # Original (unresolved) header templates per resource, captured before the
-        # first batch resolves them. Re-resolving from these each batch keeps
-        # time-sensitive values (now_ms()/rsa_sign) fresh instead of frozen.
-        self._original_header_templates: Dict[str, Dict[str, Any]] = {}
         self.spark_manager = None
         self.spark: SparkSession | None = None
         self._telemetry = TelemetryManager()

--- a/src/handler/dynamic_handler.py
+++ b/src/handler/dynamic_handler.py
@@ -127,6 +127,10 @@ class DynamicHandler(BaseHandler):
         self.config = settings.pipeline_config
         self.record_limit = record_limit
         self.backfill_mode = backfill_mode
+        # Original (unresolved) header templates per resource, captured before the
+        # first batch resolves them. Re-resolving from these each batch keeps
+        # time-sensitive values (now_ms()/rsa_sign) fresh instead of frozen.
+        self._original_header_templates: Dict[str, Dict[str, Any]] = {}
         self.spark_manager = None
         self.spark: SparkSession | None = None
         self._telemetry = TelemetryManager()
@@ -1872,15 +1876,25 @@ class DynamicHandler(BaseHandler):
             resource_meta: Resource metadata
         """
         self._current_value_resolver = get_resolver(self.redis_context)
-        # Resolve resource-level headers merged with source defaults before the fetch
-        if resource_config.headers or source_config.headers:
-            headers_to_resolve = {
+        # Resolve resource-level headers merged with source defaults before the fetch.
+        # Cache the ORIGINAL (unresolved) templates the first time we see this
+        # resource, then always resolve from that snapshot. Resolving overwrites
+        # resource_config.headers with concrete values, so without this snapshot the
+        # second batch would re-merge the already-resolved headers and reuse the first
+        # batch's frozen now_ms()/rsa_sign output -- causing time-limited auth
+        # signatures (e.g. Walmart WM_SEC) to expire partway through a multi-batch run.
+        if not hasattr(self, "_original_header_templates"):
+            self._original_header_templates = {}
+        header_cache_key = f"{resource_meta.source_name}.{resource_meta.resource_name}"
+        if header_cache_key not in self._original_header_templates:
+            self._original_header_templates[header_cache_key] = {
                 **(source_config.headers or {}),
                 **(resource_config.headers or {}),
             }
-
+        header_templates = self._original_header_templates[header_cache_key]
+        if header_templates:
             resolved_resource_headers = self._resolve_resource_header_values(
-                headers_to_resolve,
+                header_templates,
                 source_name=resource_meta.source_name,
                 resource_name=resource_meta.resource_name,
             )


### PR DESCRIPTION
## Summary

_make_single_request resolved source-level header templates once and wrote the concrete values back onto resource_config.headers. Because the same resource_config is reused across every batch, batches after the first re-merged the already-resolved headers and reused the first batch's now_ms() / rsa_sign output. On multi-batch runs the frozen Walmart WM_SEC signature expired mid-run, and every remaining request failed with 401 "signature has expired" (e.g. walmart_item_catalog, which fires hundreds of signed batches over ~10 min).

This fixes it by snapshotting the original (unresolved) header templates per resource on first use and re-resolving from that snapshot every batch, so time-sensitive values stay fresh. The same shared code path is used by all Walmart sources (walmart_connect_*, walmart_nrt), so they benefit automatically.

Verified locally against walmart_item_catalog: 583 signed batches over ~13 continuous minutes with zero signature-expiry errors (previously failed within minutes). Existing handler test suite passes (89 tests).

## Checklist

- [x] I have described the change clearly enough for reviewers.
- [x] I ran lint and tests locally (or noted why not).
- [x] This PR does not include secrets, credentials, or internal-only endpoints in YAML, SQL, or docs